### PR TITLE
Spell tag fixes

### DIFF
--- a/SolastaUnfinishedBusiness/Api/Infrastructure/DictionaryExtensions.cs
+++ b/SolastaUnfinishedBusiness/Api/Infrastructure/DictionaryExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace SolastaUnfinishedBusiness.Api.Infrastructure;
+
+public static class DictionaryExtensions
+{
+    public static void TryAddRange<K, V>(this Dictionary<K, V> dict, IEnumerable<K> keys, V value)
+    {
+        foreach (var key in keys)
+        {
+            dict.TryAdd(key, value);
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Models/LevelUpContext.cs
+++ b/SolastaUnfinishedBusiness/Models/LevelUpContext.cs
@@ -374,6 +374,36 @@ internal static class LevelUpContext
             : levelUpData.OtherClassesKnownSpells;
     }
 
+    internal static void EnumerateExtraSpells(Dictionary<SpellDefinition, string> extraSpells,
+        RulesetCharacterHero hero)
+    {
+        if (hero == null) { return; }
+
+        foreach (var feature in hero.GetFeaturesByType<FeatureDefinitionAutoPreparedSpells>())
+        {
+            foreach (var spell in feature.AutoPreparedSpellsGroups.SelectMany(x => x.SpellsList))
+            {
+                extraSpells.TryAdd(spell, feature.AutoPreparedTag);
+            }
+        }
+
+        if (hero.TryGetHeroBuildingData(out var data))
+        {
+            var features = data.levelupTrainedFeats
+                .SelectMany(x => x.Value)
+                .SelectMany(f => f.Features)
+                .OfType<FeatureDefinitionAutoPreparedSpells>();
+
+            foreach (var feature in features)
+            {
+                foreach (var spell in feature.AutoPreparedSpellsGroups.SelectMany(x => x.SpellsList))
+                {
+                    extraSpells.TryAdd(spell, feature.AutoPreparedTag);
+                }
+            }
+        }
+    }
+
     internal static void GrantItemsIfRequired([NotNull] RulesetCharacterHero hero)
     {
         if (!LevelUpTab.TryGetValue(hero, out var levelUpData) || !levelUpData.IsLevelingUp)

--- a/SolastaUnfinishedBusiness/Models/LevelUpContext.cs
+++ b/SolastaUnfinishedBusiness/Models/LevelUpContext.cs
@@ -5,6 +5,7 @@ using HarmonyLib;
 using JetBrains.Annotations;
 using SolastaUnfinishedBusiness.Api;
 using SolastaUnfinishedBusiness.Api.Extensions;
+using SolastaUnfinishedBusiness.Api.Infrastructure;
 using SolastaUnfinishedBusiness.CustomInterfaces;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.CharacterClassDefinitions;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.ItemDefinitions;
@@ -13,6 +14,9 @@ namespace SolastaUnfinishedBusiness.Models;
 
 internal static class LevelUpContext
 {
+    internal const string ExtraClassTag = "@Class";
+    internal const string ExtraSubclassTag = "@Subclass";
+
     // keeps a tab on all heroes leveling up
     private static readonly Dictionary<RulesetCharacterHero, LevelUpData> LevelUpTab = new();
 
@@ -321,36 +325,50 @@ internal static class LevelUpContext
     }
 
     [NotNull]
-    private static HashSet<SpellDefinition> CacheOtherClassesKnownSpells([NotNull] RulesetCharacterHero hero)
+    private static Dictionary<SpellDefinition, string> CacheOtherClassesKnownSpells([NotNull] RulesetCharacterHero hero)
     {
         var selectedRepertoire = GetSelectedClassOrSubclassRepertoire(hero);
-        var knownSpells = new List<SpellDefinition>();
+        var knownSpells = new Dictionary<SpellDefinition, string>();
 
         foreach (var spellRepertoire in hero.SpellRepertoires
                      .Where(x => x != selectedRepertoire))
         {
             var castingFeature = spellRepertoire.SpellCastingFeature;
+            var tag = "Multiclass";
+            if (spellRepertoire.spellCastingClass != null)
+            {
+                tag = $"{ExtraClassTag}|{spellRepertoire.spellCastingClass.Name}";
+            }
+            else if (spellRepertoire.spellCastingSubclass != null)
+            {
+                tag = $"{ExtraSubclassTag}|{spellRepertoire.spellCastingSubclass.Name}";
+            }
+            else if (spellRepertoire.spellCastingRace != null)
+            {
+                tag = $"Race";
+            }
 
             switch (castingFeature.spellKnowledge)
             {
                 case RuleDefinitions.SpellKnowledge.Selection:
-                    knownSpells.AddRange(spellRepertoire.AutoPreparedSpells);
-                    knownSpells.AddRange(spellRepertoire.KnownCantrips);
-                    knownSpells.AddRange(spellRepertoire.KnownSpells);
+                    knownSpells.TryAddRange(spellRepertoire.AutoPreparedSpells, tag);
+                    knownSpells.TryAddRange(spellRepertoire.KnownCantrips, tag);
+                    knownSpells.TryAddRange(spellRepertoire.KnownSpells, tag);
                     break;
                 case RuleDefinitions.SpellKnowledge.Spellbook:
-                    knownSpells.AddRange(spellRepertoire.AutoPreparedSpells);
-                    knownSpells.AddRange(spellRepertoire.KnownCantrips);
-                    knownSpells.AddRange(spellRepertoire.KnownSpells);
-                    knownSpells.AddRange(spellRepertoire.EnumerateAvailableScribedSpells());
+                    knownSpells.TryAddRange(spellRepertoire.AutoPreparedSpells, tag);
+                    knownSpells.TryAddRange(spellRepertoire.KnownCantrips, tag);
+                    knownSpells.TryAddRange(spellRepertoire.KnownSpells, tag);
+                    knownSpells.TryAddRange(spellRepertoire.EnumerateAvailableScribedSpells(), tag);
                     break;
                 case RuleDefinitions.SpellKnowledge.WholeList:
-                    knownSpells.AddRange(castingFeature.SpellListDefinition.SpellsByLevel.SelectMany(s => s.Spells));
+                    knownSpells.TryAddRange(castingFeature.SpellListDefinition.SpellsByLevel.SelectMany(s => s.Spells),
+                        tag);
                     break;
             }
         }
 
-        return knownSpells.ToHashSet();
+        return knownSpells;
     }
 
     internal static HashSet<SpellDefinition> GetAllowedSpells([NotNull] RulesetCharacterHero hero)
@@ -367,10 +385,10 @@ internal static class LevelUpContext
             : levelUpData.AllowedAutoPreparedSpells;
     }
 
-    internal static HashSet<SpellDefinition> GetOtherClassesKnownSpells([NotNull] RulesetCharacterHero hero)
+    internal static Dictionary<SpellDefinition, string> GetOtherClassesKnownSpells([NotNull] RulesetCharacterHero hero)
     {
         return !LevelUpTab.TryGetValue(hero, out var levelUpData)
-            ? new HashSet<SpellDefinition>()
+            ? new Dictionary<SpellDefinition, string>()
             : levelUpData.OtherClassesKnownSpells;
     }
 
@@ -598,7 +616,7 @@ internal static class LevelUpContext
         {
             var otherClassesKnownSpells = GetOtherClassesKnownSpells(hero);
 
-            __result.RemoveAll(x => otherClassesKnownSpells.Contains(x));
+            __result.RemoveAll(x => otherClassesKnownSpells.ContainsKey(x));
         }
         else
         {
@@ -651,6 +669,6 @@ internal static class LevelUpContext
         internal HashSet<SpellDefinition> AllowedAutoPreparedSpells =>
             CacheAllowedAutoPreparedSpells(SelectedClassFeatures);
 
-        internal HashSet<SpellDefinition> OtherClassesKnownSpells => CacheOtherClassesKnownSpells(Hero);
+        internal Dictionary<SpellDefinition, string> OtherClassesKnownSpells => CacheOtherClassesKnownSpells(Hero);
     }
 }

--- a/SolastaUnfinishedBusiness/Models/MulticlassGameUiContext.cs
+++ b/SolastaUnfinishedBusiness/Models/MulticlassGameUiContext.cs
@@ -558,6 +558,10 @@ internal static class MulticlassGameUiContext
             FilterMulticlassBleeding(group, localHeroCharacter, allSpells, group.autoPreparedSpells, pointPool,
                 group.extraSpellsMap);
         }
+        
+        //Properly tag and not allow to pick spells that are auto-prepared from various features
+        LevelUpContext.EnumerateExtraSpells(group.extraSpellsMap, localHeroCharacter);
+        group.autoPreparedSpells.AddRange(group.extraSpellsMap.Keys);
 
         group.CommonBind(null, unlearn ? SpellBox.BindMode.Unlearn : SpellBox.BindMode.Learning, spellBoxChanged,
             allSpells, null, null, group.autoPreparedSpells, unlearnedSpells, autoPrepareTag,

--- a/SolastaUnfinishedBusiness/Models/MulticlassGameUiContext.cs
+++ b/SolastaUnfinishedBusiness/Models/MulticlassGameUiContext.cs
@@ -647,14 +647,16 @@ internal static class MulticlassGameUiContext
             : LevelUpContext.GetAllowedSpells(caster).Where(x => x.SpellLevel == spellLevel).ToList();
 
         var otherClassesKnownSpells = LevelUpContext.GetOtherClassesKnownSpells(caster)
-            .Where(x => x.SpellLevel == spellLevel).ToList();
+            .Where(x => x.Key.SpellLevel == spellLevel).ToList();
 
-        allSpells.RemoveAll(x => !allowedSpells.Contains(x) && !otherClassesKnownSpells.Contains(x));
+        allSpells.RemoveAll(x => !allowedSpells.Contains(x) && !otherClassesKnownSpells.Any(p => p.Key == x));
 
-        foreach (var spell in otherClassesKnownSpells)
+        foreach (var pair in otherClassesKnownSpells)
         {
+            var spell = pair.Key;
+
             //Add multiclass tag to spells known from other classes
-            extraSpellsMap.TryAdd(spell, "Multiclass");
+            extraSpellsMap.TryAdd(spell, pair.Value);
 
             // displays known spells from other classes
             if (!Main.Settings.DisplayAllKnownSpellsDuringLevelUp)

--- a/SolastaUnfinishedBusiness/Models/TranslatorContext.cs
+++ b/SolastaUnfinishedBusiness/Models/TranslatorContext.cs
@@ -212,6 +212,11 @@ internal static class TranslatorContext
         Main.Logger.Log($"{lineCount} {languageCode} translation terms loaded.");
     }
 
+    internal static bool HasTranslation(string term)
+    {
+        return LocalizationManager.Sources[0].ContainsTerm(term);
+    }
+
     internal sealed class TranslatorBehaviour : MonoBehaviour
     {
         internal const string UbTranslationTag = "UB auto translation\n";

--- a/SolastaUnfinishedBusiness/Patches/SpellBoxPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/SpellBoxPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
+using SolastaUnfinishedBusiness.Api;
 using SolastaUnfinishedBusiness.Models;
 
 namespace SolastaUnfinishedBusiness.Patches;
@@ -10,18 +11,30 @@ public static class SpellBoxPatcher
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     public static class Bind_Patch
     {
+        private static string extraTag;
+
         public static void Prefix(
             SpellBox __instance,
-            bool autoPrepared,
             ref string autoPreparedTag,
-            bool extraSpell,
             ref string extraSpellTag,
             SpellBox.BindMode bindMode
         )
         {
+            if (string.IsNullOrEmpty(extraSpellTag)) { return; }
+
+            //PATCH: show actual class/subclass name in the multiclass tag during spell selection on levelup
+            if (extraSpellTag.StartsWith(LevelUpContext.ExtraClassTag)
+                || extraSpellTag.StartsWith(LevelUpContext.ExtraSubclassTag))
+            {
+                //store original extra tag and reset both - actual texts would be handled on Postfix for this case
+                extraTag = extraSpellTag;
+                autoPreparedTag = null;
+                extraSpellTag = null;
+                return;
+            }
+
             //PATCH: if extra spell tag has no translation, but auto prepared translation for same tag exists - use that one.
-            if (string.IsNullOrEmpty(extraSpellTag)
-                || TranslatorContext.HasTranslation($"Screen/&{extraSpellTag}ExtraSpellTitle")
+            if (TranslatorContext.HasTranslation($"Screen/&{extraSpellTag}ExtraSpellTitle")
                 || !TranslatorContext.HasTranslation($"Screen/&{extraSpellTag}SpellTitle"))
             {
                 return;
@@ -29,6 +42,38 @@ public static class SpellBoxPatcher
 
             autoPreparedTag = extraSpellTag;
             extraSpellTag = null;
+        }
+
+        public static void Postfix(SpellBox __instance)
+        {
+            //PATCH: show actual class/subclass name in the multiclass tag during spell selection on levelup
+            if (string.IsNullOrEmpty(extraTag)) { return; }
+
+            var parts = extraTag.Split('|');
+            extraTag = null;
+
+            if (parts.Length != 2) { return; }
+
+            var type = parts[0];
+            var name = parts[1];
+
+            const string classFormat = "Screen/&ClassExtraSpellDescriptionFormat";
+            const string subclassFormat = "Screen/&SubclassClassExtraSpellDescriptionFormat";
+
+            if (type == LevelUpContext.ExtraClassTag &&
+                DatabaseHelper.TryGetDefinition<CharacterClassDefinition>(name, out var classDef))
+            {
+                name = classDef.FormatTitle();
+                __instance.autoPreparedTitle.Text = name;
+                __instance.autoPreparedTooltip.Content = Gui.Format(classFormat, name);
+            }
+            else if (type == LevelUpContext.ExtraSubclassTag &&
+                     DatabaseHelper.TryGetDefinition<CharacterSubclassDefinition>(name, out var subDef))
+            {
+                name = subDef.FormatTitle();
+                __instance.autoPreparedTitle.Text = name;
+                __instance.autoPreparedTooltip.Content = Gui.Format(subclassFormat, name);
+            }
         }
     }
 }

--- a/SolastaUnfinishedBusiness/Patches/SpellBoxPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/SpellBoxPatcher.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaUnfinishedBusiness.Models;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+public static class SpellBoxPatcher
+{
+    [HarmonyPatch(typeof(SpellBox), "Bind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    public static class Bind_Patch
+    {
+        public static void Prefix(
+            SpellBox __instance,
+            bool autoPrepared,
+            ref string autoPreparedTag,
+            bool extraSpell,
+            ref string extraSpellTag,
+            SpellBox.BindMode bindMode
+        )
+        {
+            //PATCH: if extra spell tag has no translation, but auto prepared translation for same tag exists - use that one.
+            if (string.IsNullOrEmpty(extraSpellTag)
+                || TranslatorContext.HasTranslation($"Screen/&{extraSpellTag}ExtraSpellTitle")
+                || !TranslatorContext.HasTranslation($"Screen/&{extraSpellTag}SpellTitle"))
+            {
+                return;
+            }
+
+            autoPreparedTag = extraSpellTag;
+            extraSpellTag = null;
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Patches/SpellsByLevelGroupPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/SpellsByLevelGroupPatcher.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaUnfinishedBusiness.Models;
+using UnityEngine;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+public class SpellsByLevelGroupPatcher
+{
+    [HarmonyPatch(typeof(SpellsByLevelGroup), "CommonBind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    public static class CommonBind_Patch
+    {
+        public static void Prefix(
+            SpellsByLevelGroup __instance,
+            RulesetCharacter caster,
+            Dictionary<SpellDefinition, string> extraSpellsMap
+        )
+        {
+            //PATCH: add all auto prepared spells to extra apells map, so that different sources of auto spells won't bleed their tag
+            LevelUpContext.EnumerateExtraSpells(extraSpellsMap, caster as RulesetCharacterHero);
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Subclasses/WizardDeadMaster.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/WizardDeadMaster.cs
@@ -31,6 +31,7 @@ internal sealed class WizardDeadMaster : AbstractSubclass
             .Create("AutoPreparedSpellsDeadMaster")
             .SetGuiPresentation(Category.Feature)
             .SetSpellcastingClass(CharacterClassDefinitions.Wizard)
+            .SetAutoTag("DeadMaster")
             .SetPreparedSpellGroups(GetDeadSpellAutoPreparedGroups())
             .AddToDB();
 

--- a/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
@@ -80,3 +80,7 @@ UI/&RecipeFilterAmmunition=Ammunition
 UI/&RecipeFilterArmor=Armor
 UI/&RecipeFilterUsableDevices=Usable Devices
 UI/&RecipeFilterWeapons=Weapons
+Screen/&RaceExtraSpellDescription=You know this spell from your heritage.
+Screen/&RaceExtraSpellTitle=Heritage
+Screen/&ClassExtraSpellDescriptionFormat=You know this spell from {0} class.
+Screen/&SubclassClassExtraSpellDescriptionFormat=You know this spell from {0} subclass.

--- a/SolastaUnfinishedBusiness/Translations/en/SubClasses/WizardDeadMaster-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/SubClasses/WizardDeadMaster-en.txt
@@ -12,3 +12,5 @@ Subclass/&WizardDeadMasterDescription=Dead Masters learn to manipulate the energ
 Subclass/&WizardDeadMasterTitle=Dead Master
 Spell/&SpellRaiseDeadFormatDescription=Summons <b>{0}</b>:\n{1}
 Spell/&SpellRaiseDeadFormatTitle=Raise {0}
+Screen/&DeadMasterSpellDescription=This Dead Master spell is always prepared.
+Screen/&DeadMasterSpellTitle=Undead


### PR DESCRIPTION
- do not allow picking spells that are auto-prepared from features/feats (including ones gained on this level)
- fixed auto prepared spell tag bleeding in spell inspection/preparation screen
- show actual class/subclass name in the multiclass tag when selecting spells during levelup
- added auto-prepared tag to Dead Master spells
- if there's no translation for ExtraSpell tag, but there's translation for AutoPrepared tag of same name - use it