### PR TITLE
Fixed one more signature

### DIFF
--- a/SolastaUnfinishedBusiness/Patches/CharacterActionMagicEffectPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/CharacterActionMagicEffectPatcher.cs
@@ -183,7 +183,8 @@ public static class CharacterActionMagicEffectPatcher
         typeof(RulesetItem), // targetITem,
         typeof(RuleDefinitions.EffectSourceType), // sourceType,
         typeof(int), // ref damageReceive
-        typeof(bool) //out damageAbsorbedByTemporaryHitPoints
+        typeof(bool), //out damageAbsorbedByTemporaryHitPoints,
+        typeof(bool) // out terminateEffectOnTarget
     }, new[]
     {
         ArgumentType.Normal, // caster
@@ -205,6 +206,7 @@ public static class CharacterActionMagicEffectPatcher
         ArgumentType.Normal, // sourceType,
         ArgumentType.Ref, //ref damageReceive
         ArgumentType.Out, //out damageAbsorbedByTemporaryHitPoints
+        ArgumentType.Out, //out terminateEffectOnTarget
     })]
     public static class ApplyForms_Patch
     {


### PR DESCRIPTION
This fixes this issue in 1.14.31

```
[SolastaUnfinishedBusiness] [Error] HarmonyLib.HarmonyException: Patching exception in method null ---> System.ArgumentException: Undefined target method for patch method static System.Collections.Generic.IEnumerable`1<HarmonyLib.CodeInstruction> SolastaUnfinishedBusiness.Patches.ApplyForms_Patch::Transpiler(System.Collections.Generic.IEnumerable`1<HarmonyLib.CodeInstruction> instructions)
  at HarmonyLib.PatchClassProcessor.PatchWithAttributes (System.Reflection.MethodBase& lastOriginal) [0x00047] in <255414689d344b1385ae719f6cce8c55>:0 
  at HarmonyLib.PatchClassProcessor.Patch () [0x00068] in <255414689d344b1385ae719f6cce8c55>:0 
   --- End of inner exception stack trace ---
  at HarmonyLib.PatchClassProcessor.ReportException (System.Exception exception, System.Reflection.MethodBase original) [0x00127] in <255414689d344b1385ae719f6cce8c55>:0 
  at HarmonyLib.PatchClassProcessor.Patch () [0x00093] in <255414689d344b1385ae719f6cce8c55>:0 
  at SolastaUnfinishedBusiness.Api.ModKit.ModManager`2[TCore,TSettings].Enable (UnityModManagerNet.UnityModManager+ModEntry modEntry, System.Reflection.Assembly assembly) [0x0008f] in <942a01f68f30431488f73c09af8f4d85>:0 
```

there is still this issue: 
```
[SolastaUnfinishedBusiness] [Error] HarmonyLib.HarmonyException: Patching exception in method System.Boolean CursorLocationBattleFriendlyTurn::IsValidAttack(GameLocationCharacter attacker, GameLocationCharacter defender, CursorType& attackCursor) ---> System.FormatException: Method System.Boolean CursorLocationBattleFriendlyTurn::IsValidAttack(GameLocationCharacter attacker, GameLocationCharacter defender, CursorType& attackCursor) cannot be patched. Reason: Invalid IL code in (wrapper dynamic-method) CursorLocationBattleFriendlyTurn:CursorLocationBattleFriendlyTurn.IsValidAttack_Patch0 (CursorLocationBattleFriendlyTurn,GameLocationCharacter,GameLocationCharacter,CursorDefinitions/CursorType&): IL_00d7: call      0x00000023


  at HarmonyLib.PatchFunctions.UpdateWrapper (System.Reflection.MethodBase original, HarmonyLib.PatchInfo patchInfo) [0x0008c] in <255414689d344b1385ae719f6cce8c55>:0 
  at HarmonyLib.PatchClassProcessor.ProcessPatchJob (HarmonyLib.PatchJobs`1+Job[T] job) [0x000bb] in <255414689d344b1385ae719f6cce8c55>:0 
   --- End of inner exception stack trace ---
  at HarmonyLib.PatchClassProcessor.ReportException (System.Exception exception, System.Reflection.MethodBase original) [0x0010f] in <255414689d344b1385ae719f6cce8c55>:0 
  at HarmonyLib.PatchClassProcessor.Patch () [0x00093] in <255414689d344b1385ae719f6cce8c55>:0 
  at SolastaUnfinishedBusiness.Api.ModKit.ModManager`2[TCore,TSettings].Enable (UnityModManagerNet.UnityModManager+ModEntry modEntry, System.Reflection.Assembly assembly) [0x0008f] in <942a01f68f30431488f73c09af8f4d85>:0 
  ```
  that I'm not sure how to fix - I think the IsValidAttack maybe now has one more parameter, but I'm not sure how to pass it through the proxy - this issue I'm leaving to you.