### PR TITLE
Wardancer momentum debuff fix for spears

### DIFF
--- a/SolastaUnfinishedBusiness/Subclasses/CollegeOfWarDancer.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/CollegeOfWarDancer.cs
@@ -476,7 +476,7 @@ internal sealed class CollegeOfWarDancer : AbstractSubclass
 
         public void ModifyAttackMode(RulesetCharacter character, RulesetAttackMode attackMode)
         {
-            if (attackMode == null || ValidatorsWeapon.IsRanged(attackMode))
+            if (attackMode == null || !ValidatorsWeapon.IsMelee(attackMode))
             {
                 return;
             }


### PR DESCRIPTION
tweaked momentum debuff checks to work properly for thrown melee weapons like spears

closes #2232