### PR TITLE
Quick fix to soulblade's weapon empower not limiting 2h weapons

### DIFF
--- a/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
@@ -1,4 +1,6 @@
-﻿using SolastaUnfinishedBusiness.Builders;
+﻿using System.Linq;
+using SolastaUnfinishedBusiness.Api.Extensions;
+using SolastaUnfinishedBusiness.Builders;
 using SolastaUnfinishedBusiness.Builders.Features;
 using SolastaUnfinishedBusiness.CustomBehaviors;
 using static RuleDefinitions;
@@ -108,8 +110,26 @@ internal sealed class PatronSoulBlade : AbstractSubclass
     private static bool CanWeaponBeEmpowered(RulesetCharacter character, RulesetItem item)
     {
         var definition = item.ItemDefinition;
-        return definition.IsWeapon && character.IsProficientWithItem(definition)
-            && !definition.WeaponDescription.WeaponTags.Contains(TagsDefinitions.WeaponTagTwoHanded);
+        if (!definition.IsWeapon || !character.IsProficientWithItem(definition))
+        {
+            return false;
+        }
+        if (!definition.WeaponDescription.WeaponTags.Contains(TagsDefinitions.WeaponTagTwoHanded))
+        {
+            return true;
+        }
+        if (FeatureDefinitionFeatureSets.FeatureSetPactBlade.FeatureSet.All(f => character.HasAnyFeature(f)))
+        {
+            if (definition.WeaponDescription.WeaponTypeDefinition.WeaponProximity == AttackProximity.Melee)
+            {
+                return true;
+            }
+            if (character is RulesetCharacterHero hero)
+            {
+                return hero.InvocationProficiencies.Contains("InvocationImprovedPactWeapon");
+            }
+        }
+        return false;
     }
 
     internal override CharacterSubclassDefinition Subclass { get; }

--- a/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
@@ -118,16 +118,10 @@ internal sealed class PatronSoulBlade : AbstractSubclass
         {
             return true;
         }
-        if (FeatureDefinitionFeatureSets.FeatureSetPactBlade.FeatureSet.All(f => character.HasAnyFeature(f)))
+        if (character is RulesetCharacterHero hero && hero.ActiveFeatures.Any(p => p.Value.Contains(FeatureDefinitionFeatureSets.FeatureSetPactBlade)))
         {
-            if (definition.WeaponDescription.WeaponTypeDefinition.WeaponProximity == AttackProximity.Melee)
-            {
-                return true;
-            }
-            if (character is RulesetCharacterHero hero)
-            {
-                return hero.InvocationProficiencies.Contains("InvocationImprovedPactWeapon");
-            }
+            return hero.InvocationProficiencies.Contains("InvocationImprovedPactWeapon") ||
+                definition.WeaponDescription.WeaponTypeDefinition.WeaponProximity == AttackProximity.Melee;
         }
         return false;
     }

--- a/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
@@ -35,14 +35,15 @@ internal sealed class PatronSoulBlade : AbstractSubclass
             .Create("PowerSoulBladeEmpowerWeapon")
             .SetGuiPresentation(Category.Feature, PowerOathOfDevotionSacredWeapon)
             .SetUniqueInstance()
-            .SetCustomSubFeatures(SkipEffectRemovalOnLocationChange.Always)
+            .SetCustomSubFeatures(SkipEffectRemovalOnLocationChange.Always,
+                new CustomItemFilter(CanWeaponBeEmpowered))
             .SetUsesFixed(ActivationTime.Action, RechargeRate.ShortRest)
             .SetExplicitAbilityScore(AttributeDefinitions.Charisma)
             .SetEffectDescription(EffectDescriptionBuilder.Create()
                 .SetDurationData(DurationType.Permanent)
                 .SetTargetingData(Side.Ally, RangeType.Self, 0, TargetType.Item,
                     //TODO: with new Inventor code we can make it RAW: implement target limiter for the weapon to work on 1-hand or pact weapon
-                    itemSelectionType: ActionDefinitions.ItemSelectionType.Weapon)
+                    itemSelectionType: ActionDefinitions.ItemSelectionType.Carried)
                 .SetEffectForms(EffectFormBuilder.Create()
                     .SetItemPropertyForm(
                         ItemPropertyUsage.Unlimited,
@@ -102,6 +103,13 @@ internal sealed class PatronSoulBlade : AbstractSubclass
             .AddFeaturesAtLevel(10,
                 powerSoulBladeSoulShield)
             .AddToDB();
+    }
+
+    private static bool CanWeaponBeEmpowered(RulesetCharacter character, RulesetItem item)
+    {
+        var definition = item.ItemDefinition;
+        return definition.IsWeapon && character.IsProficientWithItem(definition)
+            && !definition.WeaponDescription.WeaponTags.Contains(TagsDefinitions.WeaponTagTwoHanded);
     }
 
     internal override CharacterSubclassDefinition Subclass { get; }


### PR DESCRIPTION
Self-explanatory. Attached a CustomItemFilter to the empowering feature, so that it would filter out non-proficient or 2h weapons.

~~Btw, is there a discord server or smth for more informal questions about the mod codebase? I'm trying to recreate Monk's dedicated weapon feature, which in simplified version is very similar to bladelock's empowering, but somehow `AbilityScoreReplacement.DexterityIfBetterThanStrength` isn't working, so I had to did `.SetCustomSubFeatures(new CanUseAttributeForWeapon` thing.~~ Edit: nevermind, i found the discord button in the mod. im blind lol