### PR TITLE
1.4.33.21

### DIFF
--- a/SolastaUnfinishedBusiness/Builders/EffectDescriptionBuilder.cs
+++ b/SolastaUnfinishedBusiness/Builders/EffectDescriptionBuilder.cs
@@ -199,6 +199,7 @@ internal class EffectDescriptionBuilder
         int durationParameter = 0,
         TurnOccurenceType endOfEffect = TurnOccurenceType.EndOfTurn)
     {
+        // ReSharper disable once InvocationIsSkipped
         PreConditions.IsValidDuration(durationType, durationParameter);
 
         effect.durationParameter = durationParameter;

--- a/SolastaUnfinishedBusiness/Changelog.txt
+++ b/SolastaUnfinishedBusiness/Changelog.txt
@@ -1,9 +1,11 @@
 CHANGES:
 
-- added Skin of Retribution level 1 spell
-- fixed Bow Mastery missing +1 on damage rolls
-- fixed Crusher push allowing more than 1 use per turn
-- fixed Sorlocks not allowing pact slots to sorcery points
+- added Discretion of The Coedymwarth to the ranged combat group in addition to the armor one
+- fixed Oath of Ancients to correctly apply aura of warding power
+- fixed Skin of Distribution to correctly increase cold damage on upcast
+- fixed Slasher to correctly apply detrimental condition to defender
+- fixed Way of The Dragon dragon breath description to correctly say proficiency bonus usage
+- fixed wrong interaction between Level20 and Override Min Max Level settings
 
 
 

--- a/SolastaUnfinishedBusiness/ChangelogHistory.txt
+++ b/SolastaUnfinishedBusiness/ChangelogHistory.txt
@@ -1,5 +1,14 @@
 ﻿CHANGES:
 
+1.4.33.21:
+
+- added Discretion of The Coedymwarth to the ranged combat group in addition to the armor one
+- fixed Oath of Ancients to correctly apply aura of warding power
+- fixed Skin of Distribution to correctly increase cold damage on upcast
+- fixed Slasher to correctly apply detrimental condition to defender
+- fixed Way of The Dragon dragon breath description to correctly say proficiency bonus usage
+- fixed wrong interaction between Level20 and Override Min Max Level settings
+
 1.4.33.20:
 
 - added Skin of Retribution level 1 spell

--- a/SolastaUnfinishedBusiness/Feats/MeleeCombatFeats.cs
+++ b/SolastaUnfinishedBusiness/Feats/MeleeCombatFeats.cs
@@ -594,7 +594,7 @@ internal static class MeleeCombatFeats
                     attacker.RulesetCharacter.Guid,
                     attacker.RulesetCharacter.CurrentFaction.Name);
 
-                attacker.RulesetCharacter.AddConditionOfCategory(AttributeDefinitions.TagCombat, rulesetCondition);
+                defender.RulesetCharacter.AddConditionOfCategory(AttributeDefinitions.TagCombat, rulesetCondition);
             }
 
             if (outcome is not RollOutcome.CriticalSuccess)

--- a/SolastaUnfinishedBusiness/Info.json
+++ b/SolastaUnfinishedBusiness/Info.json
@@ -1,7 +1,7 @@
 {
   "Id": "SolastaUnfinishedBusiness",
   "DisplayName": "Unfinished Business [UB1]",
-  "Version": "1.4.33.20",
+  "Version": "1.4.33.21",
   "GameVersion": "1.4.33",
   "ManagerVersion": "0.24.0",
   "AssemblyName": "SolastaUnfinishedBusiness.dll",

--- a/SolastaUnfinishedBusiness/Patches/GameCampaignPartyPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/GameCampaignPartyPatcher.cs
@@ -2,7 +2,6 @@
 using HarmonyLib;
 using JetBrains.Annotations;
 using SolastaUnfinishedBusiness.Models;
-using UnityEngine;
 
 namespace SolastaUnfinishedBusiness.Patches;
 

--- a/SolastaUnfinishedBusiness/Patches/RulesetCharacterPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetCharacterPatcher.cs
@@ -580,6 +580,7 @@ public static class RulesetCharacterPatcher
     [UsedImplicitly]
     public static class RollAttack_Patch
     {
+#if false
         private static int FixCriticalDeterminationAndMirrorImageLogic(
             RulesetAttribute attribute,
             RulesetCharacter rulesetCharacter,
@@ -629,6 +630,23 @@ public static class RulesetCharacterPatcher
                 new CodeInstruction(OpCodes.Ldloc_3), // rawRoll
                 new CodeInstruction(OpCodes.Ldarg_2), // target
                 new CodeInstruction(OpCodes.Ldarg, 4), // toHitTrends
+                new CodeInstruction(OpCodes.Call, method));
+        }
+#endif
+        [NotNull]
+        [UsedImplicitly]
+        public static IEnumerable<CodeInstruction> Transpiler([NotNull] IEnumerable<CodeInstruction> instructions)
+        {
+            //PATCH: support for Mirror Image - replaces target's AC with 10 + DEX bonus if we targeting mirror image
+            var currentValueMethod = typeof(RulesetAttribute).GetMethod("get_CurrentValue");
+            var method =
+                new Func<RulesetAttribute, RulesetActor, List<RuleDefinitions.TrendInfo>, int>(MirrorImageLogic.GetAC)
+                    .Method;
+
+            return instructions.ReplaceCall(currentValueMethod,
+                1, "RulesetCharacter.RollAttack",
+                new CodeInstruction(OpCodes.Ldarg_2),
+                new CodeInstruction(OpCodes.Ldarg, 4),
                 new CodeInstruction(OpCodes.Call, method));
         }
     }

--- a/SolastaUnfinishedBusiness/Patches/RulesetCharacterPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetCharacterPatcher.cs
@@ -13,7 +13,6 @@ using SolastaUnfinishedBusiness.Api.Infrastructure;
 using SolastaUnfinishedBusiness.CustomBehaviors;
 using SolastaUnfinishedBusiness.CustomInterfaces;
 using SolastaUnfinishedBusiness.Models;
-using SolastaUnfinishedBusiness.Spells;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.CharacterClassDefinitions;
 
 namespace SolastaUnfinishedBusiness.Patches;

--- a/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
+++ b/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>10</LangVersion>
     <TargetFramework>net472</TargetFramework>
-    <AssemblyVersion>1.4.33.20</AssemblyVersion>
+    <AssemblyVersion>1.4.33.21</AssemblyVersion>
     <RepositoryUrl>https://github.com/SolastaMods/SolastaUnfinishedBusiness</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Configurations>Debug;Release;Debug Install;Release Install</Configurations>

--- a/SolastaUnfinishedBusiness/Spells/SpellBuildersHelpers.cs
+++ b/SolastaUnfinishedBusiness/Spells/SpellBuildersHelpers.cs
@@ -212,20 +212,6 @@ internal static partial class SpellBuilders
 
     private sealed class ModifyMagicEffectSkinOfRetribution : IModifyMagicEffect
     {
-        private static void MaybeRemoveSkinOfRetribution(RulesetCharacter target)
-        {
-            if (target.temporaryHitPoints > 0)
-            {
-                return;
-            }
-
-            foreach (var condition in target.AllConditions
-                         .FindAll(x => x.EffectDefinitionName == "SkinOfRetribution"))
-            {
-                target.RemoveCondition(condition);
-            }
-        }
-        
         public EffectDescription ModifyEffect(
             BaseDefinition definition,
             EffectDescription effect,
@@ -239,14 +225,28 @@ internal static partial class SpellBuilders
                 return effect;
             }
 
-            MaybeRemoveSkinOfRetribution(character);
-            
             var effectLevel = rulesetCondition.EffectLevel;
             var damageForm = effect.FindFirstDamageForm();
 
             damageForm.bonusDamage *= effectLevel;
 
+            MaybeRemoveSkinOfRetribution(character);
+
             return effect;
+        }
+
+        private static void MaybeRemoveSkinOfRetribution(RulesetCharacter target)
+        {
+            if (target.temporaryHitPoints > 0)
+            {
+                return;
+            }
+
+            foreach (var condition in target.AllConditions
+                         .FindAll(x => x.EffectDefinitionName == "SkinOfRetribution"))
+            {
+                target.RemoveCondition(condition);
+            }
         }
     }
 

--- a/SolastaUnfinishedBusiness/Subclasses/MartialMarshal.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/MartialMarshal.cs
@@ -9,7 +9,6 @@ using SolastaUnfinishedBusiness.Builders.Features;
 using SolastaUnfinishedBusiness.CustomBehaviors;
 using SolastaUnfinishedBusiness.CustomInterfaces;
 using SolastaUnfinishedBusiness.CustomUI;
-using SolastaUnfinishedBusiness.Models;
 using UnityEngine;
 using static RuleDefinitions;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper;

--- a/SolastaUnfinishedBusiness/Subclasses/OathOfAncients.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/OathOfAncients.cs
@@ -1,6 +1,5 @@
 using SolastaUnfinishedBusiness.Builders;
 using SolastaUnfinishedBusiness.Builders.Features;
-using SolastaUnfinishedBusiness.Models;
 using static RuleDefinitions;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.CharacterSubclassDefinitions;
@@ -127,7 +126,7 @@ internal sealed class OathOfAncients : AbstractSubclass
             .Create(PowerPaladinAuraOfProtection, $"Power{NAME}AuraWarding")
             .SetGuiPresentation(Category.Feature)
             .AddToDB();
-        
+
         // keep it simple and ensure it'll follow any changes from Aura of Protection
         powerAuraWarding.EffectDescription.EffectForms[0] = EffectFormBuilder
             .Create()

--- a/SolastaUnfinishedBusiness/Subclasses/PathOfTheSpirits.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PathOfTheSpirits.cs
@@ -3,7 +3,6 @@ using SolastaUnfinishedBusiness.Api.Extensions;
 using SolastaUnfinishedBusiness.Builders;
 using SolastaUnfinishedBusiness.Builders.Features;
 using SolastaUnfinishedBusiness.CustomInterfaces;
-using SolastaUnfinishedBusiness.Models;
 using static FeatureDefinitionAttributeModifier;
 using static RuleDefinitions;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper;


### PR DESCRIPTION
- added Discretion of The Coedymwarth to the ranged combat group in addition to the armor one
- fixed Oath of Ancients to correctly apply aura of warding power
- fixed Skin of Distribution to correctly increase cold damage on upcast
- fixed Slasher to correctly apply detrimental condition to defender
- fixed Way of The Dragon dragon breath description to correctly say proficiency bonus usage
- fixed wrong interaction between Level20 and Override Min Max Level settings