### PR TITLE
Allow Ready Attack with lightning launcher

### DIFF
--- a/SolastaUnfinishedBusiness/Api/Extensions/GameLocationCharacterExtensions.cs
+++ b/SolastaUnfinishedBusiness/Api/Extensions/GameLocationCharacterExtensions.cs
@@ -67,6 +67,24 @@ public static class GameLocationCharacterExtensions
         return (null, null);
     }
 
+    internal static RulesetAttackMode GetFirstRangedModeThatCanBeReadied(this GameLocationCharacter instance)
+    {
+        foreach (var mode in instance.RulesetCharacter.AttackModes)
+        {
+            if (mode.ActionType != ActionType.Main)
+            {
+                continue;
+            }
+
+            if (mode.Ranged || mode.Thrown)
+            {
+                return mode;
+            }
+        }
+
+        return null;
+    }
+
     /**
      * Finds first melee attack mode that can attack target on positionBefore, but can't on positionAfter
      */

--- a/SolastaUnfinishedBusiness/Patches/GameLocationBattleManagerPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/GameLocationBattleManagerPatcher.cs
@@ -60,12 +60,53 @@ public static class GameLocationBattleManagerPatcher
             var customBindMethod =
                 new Func<List<SpellDefinition>, SpellDefinition, bool>(CustomReactionsContext.CheckAndModifyCantrips)
                     .Method;
+            
+            //PATCH: allows to ready non-standard ranged attacks (like Armorer's Lightning Launcher)
+            var customFindMethod =
+                new Func<
+                        GameLocationCharacter, // character,
+                        ActionDefinitions.Id, // actionId,
+                        bool, // getWithMostAttackNb,
+                        bool, // onlyIfRemainingUses,
+                        RulesetAttackMode //result
+                    >(FindActionAttackMode)
+                    .Method;
 
-            return instructions.ReplaceCall(
-                "Contains",
-                -1,
-                "GameLocationBattleManager.CanPerformReadiedActionOnCharacter",
-                new CodeInstruction(OpCodes.Call, customBindMethod));
+            return instructions
+                .ReplaceCall(
+                    "Contains",
+                    -1,
+                    "GameLocationBattleManager.CanPerformReadiedActionOnCharacter.Contains",
+                    new CodeInstruction(OpCodes.Call, customBindMethod)
+                )
+                .ReplaceCall(
+                    "FindActionAttackMode",
+                    -1,
+                    "GameLocationBattleManager.CanPerformReadiedActionOnCharacter.FindActionAttackMode",
+                    new CodeInstruction(OpCodes.Call, customFindMethod)
+                );
+        }
+
+        private static RulesetAttackMode FindActionAttackMode(
+            GameLocationCharacter character,
+            ActionDefinitions.Id actionId,
+            bool getWithMostAttackNb,
+            bool onlyIfRemainingUses
+            )
+        {
+            var attackMode = character.FindActionAttackMode(actionId, getWithMostAttackNb, onlyIfRemainingUses);
+            
+            if (character.ReadiedAction != ActionDefinitions.ReadyActionType.Ranged)
+            {
+                return attackMode;
+            }
+
+            if (attackMode != null && (attackMode.Ranged || attackMode.Thrown))
+            {
+                return attackMode;
+            }
+
+            return character.GetFirstRangedModeThatCanBeReadied();
         }
     }
 

--- a/SolastaUnfinishedBusiness/Patches/ReadyActionSelectionPanelPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/ReadyActionSelectionPanelPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using JetBrains.Annotations;
+using SolastaUnfinishedBusiness.Api.Extensions;
 using SolastaUnfinishedBusiness.Models;
 
 namespace SolastaUnfinishedBusiness.Patches;
@@ -18,6 +19,17 @@ public static class ReadyActionSelectionPanelPatcher
         {
             //PATCH: adds toggle button to ready action panel for 'force preferred cantrip' feature
             CustomReactionsContext.SetupForcePreferredToggle(__instance.preferredCantripSelectionGroup);
+        }
+
+        [UsedImplicitly]
+        public static void Postfix(ReadyActionSelectionPanel __instance)
+        {
+            //PATCH: allows to ready non-standard ranged attacks (like Armorer's Lightning Launcher)
+            if (!__instance.rangedAttackButton.interactable)
+            {
+                __instance.rangedAttackButton.interactable =
+                    __instance.Character.GetFirstRangedModeThatCanBeReadied() != null;
+            }
         }
     }
 }


### PR DESCRIPTION
added patches to allow to ready non-standard ranged attacks (like Armorer's Lightning Launcher)

closes #2282