### PR TITLE
Crafting recipe icons improvements

### DIFF
--- a/SolastaUnfinishedBusiness/Builders/ItemFlagDefinitionBuilder.cs
+++ b/SolastaUnfinishedBusiness/Builders/ItemFlagDefinitionBuilder.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace SolastaUnfinishedBusiness.Builders;
+
+internal class ItemFlagDefinitionBuilder : DefinitionBuilder<ItemFlagDefinition, ItemFlagDefinitionBuilder>
+{
+    internal ItemFlagDefinitionBuilder(string name, Guid namespaceGuid) : base(name, namespaceGuid)
+    {
+    }
+
+    internal ItemFlagDefinitionBuilder(ItemFlagDefinition original, string name, Guid namespaceGuid) : base(original,
+        name, namespaceGuid)
+    {
+    }
+}

--- a/SolastaUnfinishedBusiness/CustomInterfaces/TooltipModifier.cs
+++ b/SolastaUnfinishedBusiness/CustomInterfaces/TooltipModifier.cs
@@ -1,0 +1,7 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+namespace SolastaUnfinishedBusiness.CustomInterfaces;
+
+internal delegate void TooltipModifier<T>(GuiTooltip tooltip, Image img, Transform obj, T definition, object context)
+    where T : BaseDefinition;

--- a/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
@@ -308,18 +308,19 @@ internal static class GameUiDisplay
         if (UI.Toggle(Gui.Localize("ModUi/&EnableInventoryFilteringAndSorting"), ref toggle, UI.AutoWidth()))
         {
             Main.Settings.EnableInventoryFilteringAndSorting = toggle;
-            Main.Settings.EnableInventoryTaintNonProficientItemsRed = toggle;
             InventoryManagementContext.RefreshControlsVisibility();
         }
 
-        if (Main.Settings.EnableInventoryFilteringAndSorting)
+        toggle = Main.Settings.EnableInventoryTaintNonProficientItemsRed;
+        if (UI.Toggle(Gui.Localize("ModUi/&EnableInventoryTaintNonProficientItemsRed"), ref toggle, UI.AutoWidth()))
         {
-            toggle = Main.Settings.EnableInventoryTaintNonProficientItemsRed;
-            if (UI.Toggle(Gui.Localize("ModUi/&EnableInventoryTaintNonProficientItemsRed"), ref toggle,
-                    UI.AutoWidth()))
-            {
-                Main.Settings.EnableInventoryTaintNonProficientItemsRed = toggle;
-            }
+            Main.Settings.EnableInventoryTaintNonProficientItemsRed = toggle;
+        }
+
+        toggle = Main.Settings.EnableInventoryTintKnownRecipesRed;
+        if (UI.Toggle(Gui.Localize("ModUi/&EnableInventoryTintKnownRecipesRed"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.EnableInventoryTintKnownRecipesRed = toggle;
         }
 
         toggle = Main.Settings.EnableInvisibleCrownOfTheMagister;

--- a/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
@@ -329,6 +329,21 @@ internal static class GameUiDisplay
             GameUiContext.SwitchCrownOfTheMagister();
         }
 
+        toggle = Main.Settings.ShowCraftedItemOnRecipeIcon;
+        if (UI.Toggle(Gui.Localize("ModUi/&ShowCraftedItemOnRecipeIcon"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.ShowCraftedItemOnRecipeIcon = toggle;
+        }
+
+        if (Main.Settings.ShowCraftedItemOnRecipeIcon)
+        {
+            toggle = Main.Settings.SwapCraftedItemAndRecipeIcons;
+            if (UI.Toggle(Gui.Localize("ModUi/&SwapCraftedItemAndRecipeIcons"), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.SwapCraftedItemAndRecipeIcons = toggle;
+            }
+        }
+
         #endregion
 
         #region Monster

--- a/SolastaUnfinishedBusiness/Models/BootContext.cs
+++ b/SolastaUnfinishedBusiness/Models/BootContext.cs
@@ -84,6 +84,7 @@ internal static class BootContext
 
         // Item Options must be loaded after Item Crafting
         ItemCraftingMerchantContext.Load();
+        RecipeHelper.AddRecipeIcons();
 
         MerchantContext.Load();
 

--- a/SolastaUnfinishedBusiness/Models/MerchantTypeContext.cs
+++ b/SolastaUnfinishedBusiness/Models/MerchantTypeContext.cs
@@ -366,6 +366,24 @@ internal static class RecipeHelper
 
         return item.DocumentDescription.RecipeDefinition.CraftedItem;
     }
+
+    public static bool RecipeIsKnown(ItemDefinition item)
+    {
+        if (!item.IsDocument
+            || item.DocumentDescription == null
+            || item.DocumentDescription.RecipeDefinition == null)
+        {
+            return false;
+        }
+
+        var service = ServiceRepository.GetService<IGameLoreService>();
+        if (service == null)
+        {
+            return false;
+        }
+
+        return service.KnownRecipes.Contains(item.DocumentDescription.RecipeDefinition);
+    }
 }
 
 internal sealed class MerchantFilter

--- a/SolastaUnfinishedBusiness/Models/MerchantTypeContext.cs
+++ b/SolastaUnfinishedBusiness/Models/MerchantTypeContext.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using JetBrains.Annotations;
 using SolastaUnfinishedBusiness.Builders;
+using SolastaUnfinishedBusiness.CustomInterfaces;
+using UnityEngine;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.ItemFlagDefinitions;
 
@@ -279,6 +281,65 @@ internal static class RecipeHelper
         manual.inDungeonEditor = false;
 
         return manual;
+    }
+
+    internal static void AddRecipeIcons()
+    {
+        var flag = ItemFlagDefinitionBuilder
+            .Create("ItemFlagRecipeIcon")
+            .SetGuiPresentationNoContent()
+            .SetCustomSubFeatures(new TooltipModifier<ItemDefinition>((tooltip, img, obj, definition, context) =>
+            {
+                var item = Main.Settings.ShowCraftedItemOnRecipeIcon
+                    ? GetCraftedItem(definition)
+                    : null;
+
+                if (item == null)
+                {
+                    return;
+                }
+
+                if (img != null)
+                {
+                    if (img.sprite != null)
+                    {
+                        Gui.ReleaseAddressableAsset(img.sprite);
+                        img.sprite = null;
+                    }
+
+                    var spriteReference = item.GuiPresentation.SpriteReference;
+                    if (spriteReference != null && spriteReference.RuntimeKeyIsValid())
+                    {
+                        img.sprite = Gui.LoadAssetSync<Sprite>(spriteReference);
+                        if (obj != null)
+                        {
+                            obj.gameObject.SetActive(true);
+                            obj.localScale = new Vector3(2f, 2f, 1f);
+                        }
+                    }
+                }
+
+                if (tooltip != null)
+                {
+                    ServiceRepository.GetService<IGuiWrapperService>()
+                        .GetGuiItemDefinition(item.Name)
+                        .SetupTooltip(tooltip, context);
+                }
+
+            }))
+            .AddToDB();
+
+        var recipes = DatabaseRepository.GetDatabase<ItemDefinition>()
+            .Where(d => d.IsDocument)
+            .Where(d => d.DocumentDescription != null)
+            .Where(d => d.DocumentDescription.RecipeDefinition != null);
+
+        foreach (var recipe in recipes)
+        {
+            var presentation = new ItemPresentation(recipe.ItemPresentation);
+            presentation.ItemFlags.Add(flag);
+            recipe.itemPresentation = presentation;
+        }
     }
 
     [NotNull]

--- a/SolastaUnfinishedBusiness/Models/MerchantTypeContext.cs
+++ b/SolastaUnfinishedBusiness/Models/MerchantTypeContext.cs
@@ -251,6 +251,13 @@ internal static class RecipeHelper
 
     public static RecipeDefinition BuildPrimeRecipe(ItemDefinition item, ItemDefinition primed)
     {
+        if (!primed.itemPresentation.ItemFlags.Contains(ItemFlagPrimed))
+        {
+            var presentation = new ItemPresentation(primed.itemPresentation);
+            presentation.ItemFlags.Add(ItemFlagPrimed);
+            primed.itemPresentation = presentation;
+        }
+
         return RecipeDefinitionBuilder
             .Create($"RecipePrime{item.Name}")
             .SetGuiPresentation(primed.GuiPresentation.Title, GuiPresentationBuilder.EmptyString, primed)

--- a/SolastaUnfinishedBusiness/Models/MerchantTypeContext.cs
+++ b/SolastaUnfinishedBusiness/Models/MerchantTypeContext.cs
@@ -293,6 +293,18 @@ internal static class RecipeHelper
     {
         return BuildManual(BuildPrimeRecipe(item, primed), item, "Prime");
     }
+
+    public static ItemDefinition GetCraftedItem(ItemDefinition item)
+    {
+        if (!item.IsDocument
+            || item.DocumentDescription == null
+            || item.DocumentDescription.RecipeDefinition == null)
+        {
+            return null;
+        }
+
+        return item.DocumentDescription.RecipeDefinition.CraftedItem;
+    }
 }
 
 internal sealed class MerchantFilter

--- a/SolastaUnfinishedBusiness/Patches/InventorySlotBoxPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/InventorySlotBoxPatcher.cs
@@ -18,6 +18,11 @@ public static class InventorySlotBoxPatcher
         public static void Postfix(InventorySlotBox __instance)
         {
             //PATCH: Enable inventory taint non proficient items in red (paint them red)
+            TintNonProficientItems(__instance);
+        }
+
+        private static void TintNonProficientItems(InventorySlotBox box)
+        {
             if (Global.InspectedHero == null)
             {
                 return;
@@ -28,16 +33,16 @@ public static class InventorySlotBoxPatcher
                 return;
             }
 
-            if (__instance.InventorySlot?.EquipedItem == null || __instance.equipedItemImage == null)
+            if (box.InventorySlot?.EquipedItem == null || box.equipedItemImage == null)
             {
                 return;
             }
 
-            var itemDefinition = __instance.InventorySlot.EquipedItem.ItemDefinition;
+            var itemDefinition = box.InventorySlot.EquipedItem.ItemDefinition;
 
             if (!Global.InspectedHero.IsProficientWithItem(itemDefinition))
             {
-                __instance.equipedItemImage.color = Color.red;
+                box.equipedItemImage.color = Color.red;
             }
         }
     }

--- a/SolastaUnfinishedBusiness/Patches/InventorySlotBoxPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/InventorySlotBoxPatcher.cs
@@ -56,11 +56,7 @@ public static class InventorySlotBoxPatcher
 
         private static void TintNonProficientItems(InventorySlotBox box, ItemDefinition item)
         {
-            var hero = Global.InspectedHero;
-            if (hero == null)
-            {
-                return;
-            }
+            var hero = box.GuiCharacter?.RulesetCharacterHero ?? Global.InspectedHero;
 
             if (item == null || box.equipedItemImage == null)
             {
@@ -68,7 +64,7 @@ public static class InventorySlotBoxPatcher
             }
 
 
-            if ((Main.Settings.EnableInventoryTaintNonProficientItemsRed && !hero.IsProficientWithItem(item))
+            if ((Main.Settings.EnableInventoryTaintNonProficientItemsRed && !(hero?.IsProficientWithItem(item) ?? true))
                 || (Main.Settings.EnableInventoryTintKnownRecipesRed && RecipeHelper.RecipeIsKnown(item)))
             {
                 box.equipedItemImage.color = Color.red;

--- a/SolastaUnfinishedBusiness/Patches/InventorySlotBoxPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/InventorySlotBoxPatcher.cs
@@ -29,7 +29,7 @@ public static class InventorySlotBoxPatcher
             var itemDefinition = equipmentItem.ItemDefinition;
 
             //PATCH: Enable inventory taint non proficient items in red (paint them red)
-            TintNonProficientItems(__instance);
+            TintNonProficientItems(__instance, itemDefinition);
             ModifyCustomItemFlags(__instance, itemDefinition);
         }
 
@@ -54,26 +54,22 @@ public static class InventorySlotBoxPatcher
             }
         }
 
-        private static void TintNonProficientItems(InventorySlotBox box)
+        private static void TintNonProficientItems(InventorySlotBox box, ItemDefinition item)
         {
-            if (Global.InspectedHero == null)
+            var hero = Global.InspectedHero;
+            if (hero == null)
             {
                 return;
             }
 
-            if (!Main.Settings.EnableInventoryTaintNonProficientItemsRed)
+            if (item == null || box.equipedItemImage == null)
             {
                 return;
             }
 
-            if (box.InventorySlot?.EquipedItem == null || box.equipedItemImage == null)
-            {
-                return;
-            }
 
-            var itemDefinition = box.InventorySlot.EquipedItem.ItemDefinition;
-
-            if (!Global.InspectedHero.IsProficientWithItem(itemDefinition))
+            if ((Main.Settings.EnableInventoryTaintNonProficientItemsRed && !hero.IsProficientWithItem(item))
+                || (Main.Settings.EnableInventoryTintKnownRecipesRed && RecipeHelper.RecipeIsKnown(item)))
             {
                 box.equipedItemImage.color = Color.red;
             }

--- a/SolastaUnfinishedBusiness/Patches/InventorySlotBoxPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/InventorySlotBoxPatcher.cs
@@ -1,8 +1,11 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using JetBrains.Annotations;
+using SolastaUnfinishedBusiness.Api.Extensions;
+using SolastaUnfinishedBusiness.CustomInterfaces;
 using SolastaUnfinishedBusiness.Models;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace SolastaUnfinishedBusiness.Patches;
 
@@ -15,10 +18,40 @@ public static class InventorySlotBoxPatcher
     public static class RefreshState_Patch
     {
         [UsedImplicitly]
-        public static void Postfix(InventorySlotBox __instance)
+        public static void Postfix(InventorySlotBox __instance, bool overrideItem, RulesetItem itemOverride)
         {
+            var equipmentItem = overrideItem ? itemOverride : __instance.InventorySlot?.EquipedItem;
+            if (equipmentItem == null)
+            {
+                return;
+            }
+
+            var itemDefinition = equipmentItem.ItemDefinition;
+
             //PATCH: Enable inventory taint non proficient items in red (paint them red)
             TintNonProficientItems(__instance);
+            ModifyCustomItemFlags(__instance, itemDefinition);
+        }
+
+        private static void ModifyCustomItemFlags(InventorySlotBox box, ItemDefinition definition)
+        {
+            if (box.itemFlagsTableInstance == null)
+            {
+                return;
+            }
+
+            var flagsTransform = box.itemFlagsTableInstance.transform;
+            var n = flagsTransform.childCount;
+
+            for (var index = 0; index < n; index++)
+            {
+                var child = flagsTransform.GetChild(index);
+                var img = child.GetComponent<Image>();
+                var flag = definition.ItemPresentation.ItemFlags[index];
+                child.TryGetComponent<GuiTooltip>(out var tooltip);
+                var custom = flag.GetFirstSubFeatureOfType<TooltipModifier<ItemDefinition>>();
+                custom?.Invoke(tooltip, img, child, definition, null);
+            }
         }
 
         private static void TintNonProficientItems(InventorySlotBox box)
@@ -64,6 +97,34 @@ public static class InventorySlotBoxPatcher
             }
 
             __instance.equipedItemImage.color = new Color(1, 1, 1);
+        }
+    }
+
+    [HarmonyPatch(typeof(InventorySlotBox), nameof(InventorySlotBox.UnbindItemFlags))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class UnbindItemFlags_Patch
+    {
+        [UsedImplicitly]
+        public static void Prefix(InventorySlotBox __instance)
+        {
+            if (__instance.itemFlagsTableInstance == null)
+            {
+                return;
+            }
+
+            var flagsTransform = __instance.itemFlagsTableInstance.transform;
+            var n = flagsTransform.childCount;
+
+            for (var index = 0; index < n; index++)
+            {
+                var child = flagsTransform.GetChild(index);
+                child.localScale = Vector3.one;
+                if (child.TryGetComponent<GuiTooltip>(out var tooltip))
+                {
+                    tooltip.Clear();
+                }
+            }
         }
     }
 }

--- a/SolastaUnfinishedBusiness/Patches/StockUnitLinePatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/StockUnitLinePatcher.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using JetBrains.Annotations;
+using SolastaUnfinishedBusiness.Models;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -27,19 +28,6 @@ public static class StockUnitLinePatcher
         t.localScale = new Vector3(1.5f, 1.5f, 1f);
 
         return t;
-    }
-
-    private static ItemDefinition GetCraftedItem(GameStockUnit stock)
-    {
-        if (!Main.Settings.ShowCraftedItemOnRecipeIcon
-            || !stock.ItemDefinition.IsDocument
-            || stock.ItemDefinition.DocumentDescription == null
-            || stock.ItemDefinition.DocumentDescription.RecipeDefinition == null)
-        {
-            return null;
-        }
-
-        return stock.ItemDefinition.DocumentDescription.RecipeDefinition.CraftedItem;
     }
 
     private static Image SetupCraftedItem(Transform t, ItemDefinition item)
@@ -78,7 +66,9 @@ public static class StockUnitLinePatcher
         public static void Postfix(StockUnitLine __instance)
         {
             var item = GetRecipeItem(__instance.factionIncompatibleGroup, false);
-            var crafted = GetCraftedItem(__instance.StockUnit);
+            var crafted = Main.Settings.ShowCraftedItemOnRecipeIcon
+                ? RecipeHelper.GetCraftedItem(__instance.StockUnit.ItemDefinition)
+                : null;
             if (crafted == null)
             {
                 item.gameObject.SetActive(false);

--- a/SolastaUnfinishedBusiness/Patches/StockUnitLinePatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/StockUnitLinePatcher.cs
@@ -1,0 +1,111 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using JetBrains.Annotations;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+[UsedImplicitly]
+public static class StockUnitLinePatcher
+{
+    private static Transform GetRecipeItem(RectTransform factionGroup, bool justRetrieve)
+    {
+        const string NAME = "RECIPE_ITEM";
+
+        var t = factionGroup.parent.Find(NAME);
+        if (t != null || justRetrieve)
+        {
+            return t;
+        }
+
+        var item = Object.Instantiate(factionGroup.gameObject, factionGroup.parent);
+        item.name = NAME;
+        item.SetActive(true);
+        t = item.GetComponent<RectTransform>();
+        t.localPosition = new Vector3(-100, 0);
+        t.localScale = new Vector3(1.5f, 1.5f, 1f);
+
+        return t;
+    }
+
+    private static ItemDefinition GetCraftedItem(GameStockUnit stock)
+    {
+        if (!Main.Settings.ShowCraftedItemOnRecipeIcon
+            || !stock.ItemDefinition.IsDocument
+            || stock.ItemDefinition.DocumentDescription == null
+            || stock.ItemDefinition.DocumentDescription.RecipeDefinition == null)
+        {
+            return null;
+        }
+
+        return stock.ItemDefinition.DocumentDescription.RecipeDefinition.CraftedItem;
+    }
+
+    private static Image SetupCraftedItem(Transform t, ItemDefinition item)
+    {
+        if (t == null)
+        {
+            return null;
+        }
+
+        var img = t.Find("IncompatibleImage").GetComponent<Image>();
+        var tooltip = t.GetComponent<GuiTooltip>();
+        if (item != null)
+        {
+            img.color = Color.white;
+            img.sprite = Gui.LoadAssetSync<Sprite>(item.GuiPresentation.SpriteReference);
+            ServiceRepository.GetService<IGuiWrapperService>()
+                .GetGuiItemDefinition(item.Name)
+                .SetupTooltip(tooltip);
+        }
+        else if (img.sprite != null)
+        {
+            Gui.ReleaseAddressableAsset(img.sprite);
+            img.sprite = null;
+            tooltip.Clear();
+        }
+
+        return img;
+    }
+
+    [HarmonyPatch(typeof(StockUnitLine), nameof(StockUnitLine.Bind))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class Bind_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(StockUnitLine __instance)
+        {
+            var item = GetRecipeItem(__instance.factionIncompatibleGroup, false);
+            var crafted = GetCraftedItem(__instance.StockUnit);
+            if (crafted == null)
+            {
+                item.gameObject.SetActive(false);
+                __instance.itemImage.transform.localPosition = new Vector3(33, 0, 0);
+            }
+            else
+            {
+                item.gameObject.SetActive(true);
+                __instance.itemImage.transform.localPosition = new Vector3(58, 0, 0);
+                var img = SetupCraftedItem(item, crafted);
+                if (Main.Settings.SwapCraftedItemAndRecipeIcons)
+                {
+                    (img.sprite, __instance.itemImage.sprite) = (__instance.itemImage.sprite, img.sprite);
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(StockUnitLine), nameof(StockUnitLine.Unbind))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class Unbind_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(StockUnitLine __instance)
+        {
+            SetupCraftedItem(GetRecipeItem(__instance.factionIncompatibleGroup, true), null);
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Patches/TooltipFeatureItemProficiencyPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/TooltipFeatureItemProficiencyPatcher.cs
@@ -29,7 +29,7 @@ public static class TooltipFeatureItemProficiencyPatcher
 
             if (RecipeHelper.RecipeIsKnown(data.ItemDefinition))
             {
-                __instance.notProficientLabel.Text = "Tooltip/&RecipeIsKnown";
+                __instance.notProficientLabel.Text = "Failure/&FailureFlagRecipeAlreadyKnown";
                 obj.SetActive(true);
             }
         }

--- a/SolastaUnfinishedBusiness/Patches/TooltipFeatureItemProficiencyPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/TooltipFeatureItemProficiencyPatcher.cs
@@ -1,0 +1,37 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using JetBrains.Annotations;
+using SolastaUnfinishedBusiness.Models;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+[UsedImplicitly]
+public static class TooltipFeatureItemProficiencyPatcher
+{
+    [HarmonyPatch(typeof(TooltipFeatureItemProficiency), nameof(TooltipFeatureItemProficiency.Bind))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class Bind_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(TooltipFeatureItemProficiency __instance, ITooltip tooltip)
+        {
+            var obj = __instance.gameObject;
+            if (obj.activeSelf)
+            {
+                return;
+            }
+
+            if (tooltip.DataProvider is not IItemDefinitionProvider data)
+            {
+                return;
+            }
+
+            if (RecipeHelper.RecipeIsKnown(data.ItemDefinition))
+            {
+                __instance.notProficientLabel.Text = "Tooltip/&RecipeIsKnown";
+                obj.SetActive(true);
+            }
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -284,6 +284,8 @@ public class Settings : UnityModManager.ModSettings
     public bool EnableInventoryFilteringAndSorting { get; set; }
     public bool EnableInventoryTaintNonProficientItemsRed { get; set; }
     public bool EnableInvisibleCrownOfTheMagister { get; set; }
+    public bool ShowCraftedItemOnRecipeIcon { get; set; } = true;
+    public bool SwapCraftedItemAndRecipeIcons { get; set; }
 
     // Monsters
     public bool HideMonsterHitPoints { get; set; }

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -283,6 +283,7 @@ public class Settings : UnityModManager.ModSettings
     public bool DisableAutoEquip { get; set; }
     public bool EnableInventoryFilteringAndSorting { get; set; }
     public bool EnableInventoryTaintNonProficientItemsRed { get; set; }
+    public bool EnableInventoryTintKnownRecipesRed { get; set; }
     public bool EnableInvisibleCrownOfTheMagister { get; set; }
     public bool ShowCraftedItemOnRecipeIcon { get; set; } = true;
     public bool SwapCraftedItemAndRecipeIcons { get; set; }

--- a/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
@@ -107,7 +107,6 @@ Tooltip/&PreReqIs=Is {0}
 Tooltip/&PreReqIsNot=Isn't {0}
 Tooltip/&PreReqLevelFormat=Min Character Level {0}
 Tooltip/&PreReqMustKnow=Must know {0}
-Tooltip/&RecipeIsKnown=You already know this recipe.
 Tooltip/&Tag9000Title=Custom Effect
 Tooltip/&TagUnfinishedBusinessTitle=Unfinished Business
 UI/&CustomFeatureSelectionStageDescription=Select extra features for your class/subclass.

--- a/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
@@ -107,6 +107,7 @@ Tooltip/&PreReqIs=Is {0}
 Tooltip/&PreReqIsNot=Isn't {0}
 Tooltip/&PreReqLevelFormat=Min Character Level {0}
 Tooltip/&PreReqMustKnow=Must know {0}
+Tooltip/&RecipeIsKnown=You already know this recipe.
 Tooltip/&Tag9000Title=Custom Effect
 Tooltip/&TagUnfinishedBusinessTitle=Unfinished Business
 UI/&CustomFeatureSelectionStageDescription=Select extra features for your class/subclass.

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -174,6 +174,7 @@ ModUi/&SelectAll=Select All
 ModUi/&SelectSuggested=Select Suggested
 ModUi/&Services=Services
 ModUi/&SetBeltOfDwarvenKindBeardChances=<color=#D89555>Belt of Dwarvenkind</color> <color=white>beard appearing chances</color>
+ModUi/&ShowCraftedItemOnRecipeIcon=Show crafted item icon near recipe item in shop. Hovering over it will show tooltip for crafted item.
 ModUi/&ShowCraftingRecipeInDetailedTooltips=Show crafting recipe in detailed tooltips
 ModUi/&ShowDescriptions=Show Descriptions
 ModUi/&SpellInstructions=. You can individually assign each spell to any spell list or simply select the suggested set
@@ -184,6 +185,7 @@ ModUi/&StockGorimStoreWithAllNonMagicalClothing=Stock Gorim's store with all non
 ModUi/&StockGorimStoreWithAllNonMagicalInstruments=Stock Gorim's store with all non-magical musical instruments <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&StockHugoStoreWithAdditionalFoci=Stock Hugo's store with <color=#D89555>Arcane Staff</color>, <color=#D89555>Druid Neck</color>, <color=#D89555>Staff</color> and <color=#D89555>Club</color> set as foci items
 ModUi/&Subclasses=<color=#F0DAA0>Subclasses</color>
+ModUi/&SwapCraftedItemAndRecipeIcons=<i>+ Swap recipe and crafted item icons in shop.</i>
 ModUi/&TargetLanguage=Target Language
 ModUi/&Tools=Tools
 ModUi/&TotalCraftingTimeModifier=<color=white>Reduce crafting time by</color>

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -174,7 +174,7 @@ ModUi/&SelectAll=Select All
 ModUi/&SelectSuggested=Select Suggested
 ModUi/&Services=Services
 ModUi/&SetBeltOfDwarvenKindBeardChances=<color=#D89555>Belt of Dwarvenkind</color> <color=white>beard appearing chances</color>
-ModUi/&ShowCraftedItemOnRecipeIcon=Show crafted item icon near recipe item in shop. Hovering over it will show tooltip for crafted item.
+ModUi/&ShowCraftedItemOnRecipeIcon=Show crafted item icon near recipe item in shop and inventory. Hovering over it will show tooltip for crafted item.
 ModUi/&ShowCraftingRecipeInDetailedTooltips=Show crafting recipe in detailed tooltips
 ModUi/&ShowDescriptions=Show Descriptions
 ModUi/&SpellInstructions=. You can individually assign each spell to any spell list or simply select the suggested set

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -75,7 +75,8 @@ ModUi/&EnableFlexibleRaces=Enable flexible races <i><color=#F0DAA0>[assign abili
 ModUi/&EnableHotkeyDebugOverlay=Enable <color=#1E81B0>CTRL-SHIFT-(D)</color> to display the debug overlay
 ModUi/&EnableHotkeyToggleHud=Enable <color=#1E81B0>CTRL-SHIFT-(H)</color> to toggle the HUD display
 ModUi/&EnableInventoryFilteringAndSorting=Enable inventory filtering and sorting
-ModUi/&EnableInventoryTaintNonProficientItemsRed=<i>+ Taint in red any item the hero isn't proficient with</i>
+ModUi/&EnableInventoryTaintNonProficientItemsRed=Tint red any item the hero isn't proficient with
+ModUi/&EnableInventoryTintKnownRecipesRed=Tint red known recipes
 ModUi/&EnableInvisibleCrownOfTheMagister=Hide the <color=#D89555>Crown of the Magister</color> on game UI
 ModUi/&EnableLevel20=Enable level 20 <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&EnableLogDialoguesToConsole=Enable log dialogues to game console during narrative sequences


### PR DESCRIPTION
- Added option to show crafted item near recipe icon in shop and inventory (enabled by default, @ThyWoof feel free to set default to disabled)
- Added option to swap crafted item icon with recipe icon in shop
- Added option to tint red known recipes
- Known recipes will show red warning in tooltip
- Fixed non-proficient item tinting not working in inventory when opening shop (tinting in shop panel is still not implemented)
- Decoupled non-proficient item tinting option from inventory sorting option