### PR TITLE
Sentinal Reaction Fix

### DIFF
--- a/SolastaUnfinishedBusiness/CustomBehaviors/AttacksOfOpportunity.cs
+++ b/SolastaUnfinishedBusiness/CustomBehaviors/AttacksOfOpportunity.cs
@@ -266,6 +266,6 @@ internal class CustomReactionAttack
             defender,
             attackModifier) { StringParameter2 = Name };
 
-        return new ReactionRequestWarcaster(reactionParams);
+        return new ReactionRequestWarcaster(Name, reactionParams);
     }
 }

--- a/SolastaUnfinishedBusiness/CustomUI/ReactionRequestWarcaster.cs
+++ b/SolastaUnfinishedBusiness/CustomUI/ReactionRequestWarcaster.cs
@@ -15,17 +15,21 @@ internal class ReactionRequestWarcaster : ReactionRequest
 
     private readonly string type;
 
-    internal ReactionRequestWarcaster(CharacterActionParams reactionParams)
-        : base(Name, reactionParams)
+    internal ReactionRequestWarcaster(string name, CharacterActionParams reactionParams)
+        : base(name, reactionParams)
     {
         attackAction = reactionParams.ActionDefinition;
         attackModifiers.SetRange(reactionParams.ActionModifiers);
         BuildSuboptions();
         type = string.IsNullOrEmpty(ReactionParams.StringParameter2)
-            ? Name
+            ? name
             : ReactionParams.StringParameter2;
-        // ReactionParams.StringParameter2 = type;
         guiTarget = new GuiCharacter(reactionParams.targetCharacters[0]);
+    }
+    
+    internal ReactionRequestWarcaster(CharacterActionParams reactionParams)
+        : this(Name, reactionParams)
+    {
     }
 
     public override int SelectedSubOption

--- a/SolastaUnfinishedBusiness/Patches/GameLocationActionManagerPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/GameLocationActionManagerPatcher.cs
@@ -33,6 +33,13 @@ public static class GameLocationActionManagerPatcher
         public static bool Prefix(GameLocationActionManager __instance, CharacterActionParams reactionParams)
         {
             //PATCH: replace `OpportunityAttack` reaction with warcaster one
+            
+            //replace only for player characters
+            if (reactionParams.ActingCharacter.Side != RuleDefinitions.Side.Ally)
+            {
+                return true;
+            }
+
             __instance.AddInterruptRequest(new ReactionRequestWarcaster(reactionParams));
 
             return false;


### PR DESCRIPTION
Problem was happening because player characters and enemies shared name of an AoO reaction (WarcasterReaction) and new reactions were added when list was being already iterated on, leading to all sorts of problems including iterated list changed errors and multiple attacks in a row being performed. Fixed by replacing basic AoO reaction with Warcaster only for player characters. 

close #2468