### PR TITLE
Update MeleeCombatFeats.cs

### DIFF
--- a/SolastaUnfinishedBusiness/Feats/MeleeCombatFeats.cs
+++ b/SolastaUnfinishedBusiness/Feats/MeleeCombatFeats.cs
@@ -640,7 +640,7 @@ internal static class MeleeCombatFeats
             var battle = Gui.Battle;
 
             // the second check handle cases where you can attack when enemy misses you on a hit
-            if (attackMode.actionType != ActionDefinitions.ActionType.Reaction &&
+            if (attackMode.actionType != ActionDefinitions.ActionType.Reaction && battle != null &&
                 battle.ActiveContender.RulesetCharacter != defender && battle.DefenderContender != null)
             {
                 return;


### PR DESCRIPTION
Check the battle variable to make sure the ref exists; handles a bug where using a weapon outside of combat causes a null deref.

I don't just early return because this will allow blademaster rogues to apply the feat on a back stab; the validator should still pass and battle is only used in the early exit for the special case -- I'm not familiar enough with the codebase to understand precisely what that case is handling.