### PR TITLE
More wildshape tweaks

### DIFF
--- a/SolastaUnfinishedBusiness/CustomUI/CustomCharacterStatsPanel.cs
+++ b/SolastaUnfinishedBusiness/CustomUI/CustomCharacterStatsPanel.cs
@@ -70,6 +70,7 @@ public class CustomCharacterStatsPanel
     }
 
     public static CustomCharacterStatsPanel Instance => instance ??= new CustomCharacterStatsPanel();
+    public static CustomCharacterStatsPanel MaybeInstance => instance;
 
     private void UpdateVisibility()
     {

--- a/SolastaUnfinishedBusiness/CustomUI/CustomCharacterStatsPanel.cs
+++ b/SolastaUnfinishedBusiness/CustomUI/CustomCharacterStatsPanel.cs
@@ -1,0 +1,226 @@
+﻿using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace SolastaUnfinishedBusiness.CustomUI;
+
+public class CustomCharacterStatsPanel
+{
+    private static CustomCharacterStatsPanel instance;
+    private readonly AbilityScoresListingPanel abilities;
+    private readonly AttackModesPanel attacks;
+    private readonly Button button;
+
+    private readonly Transform root;
+    private readonly CharacterStatsPanel stats;
+    private bool bound;
+    private RulesetCharacter character;
+    private GuiCharacter guiCharacter;
+    private bool visible;
+
+    private CustomCharacterStatsPanel()
+    {
+        root = new GameObject().transform;
+        var inspector = Gui.GuiService.GetScreen<CharacterInspectionScreen>();
+
+        root.localPosition = new Vector3(225, 125, 0);
+        root.gameObject.SetActive(false);
+
+        var prefab = Resources.Load<GameObject>("Gui/Prefabs/Component/SmallButtonRoundImage");
+        button = Object.Instantiate(prefab).GetComponent<Button>();
+        button.gameObject.SetActive(false);
+        button.transform.localPosition = new Vector3(50, 50, 0);
+        button.onClick.AddListener(() =>
+        {
+            if (!bound) { return; }
+
+            visible = !visible;
+            UpdateVisibility();
+        });
+
+        #region Abilities
+
+        abilities = Object.Instantiate(inspector.abilityScoresListingPanelPrefab, root)
+            .GetComponent<AbilityScoresListingPanel>();
+        abilities.transform.localPosition = new Vector3(0, 100, 0);
+
+        for (var index = 0; index < AttributeDefinitions.AbilityScoreNames.Length; ++index)
+        {
+            abilities.abilityScoreBoxes.Add(Gui.GetPrefabFromPool(abilities.boxPrefab, abilities.table)
+                .GetComponent<AbilityScoreBox>());
+        }
+
+        #endregion
+
+        #region Stats
+
+        stats = Object.Instantiate(inspector.characterStatsPanelPrefab, root)
+            .GetComponent<CharacterStatsPanel>();
+        stats.transform.localPosition = new Vector3(0, 0, 0);
+
+        #endregion
+
+        #region Attacks
+
+        attacks = Gui.GetPrefabFromPool(inspector.attackModesPanelPrefab, root)
+            .GetComponent<AttackModesPanel>();
+        attacks.transform.localPosition = new Vector3(275, 200, 0);
+
+        #endregion
+    }
+
+    public static CustomCharacterStatsPanel Instance => instance ??= new CustomCharacterStatsPanel();
+
+    private void UpdateVisibility()
+    {
+        root.gameObject.SetActive(visible);
+    }
+
+    private static GameLocationBaseScreen GetActiveScreen()
+    {
+        var explore = Gui.GuiService.GetScreen<GameLocationScreenExploration>();
+        if (explore != null && explore.Visible)
+        {
+            return explore;
+        }
+
+        var battle = Gui.GuiService.GetScreen<GameLocationScreenBattle>();
+        if (battle != null && battle.Visible)
+        {
+            return battle;
+        }
+
+        return null;
+    }
+
+    public void Bind(RulesetCharacter target)
+    {
+        var screen = GetActiveScreen();
+        if (screen == null)
+        {
+            return;
+        }
+
+        character = target;
+        guiCharacter = new GuiCharacter(character);
+        var parent = screen.CharacterControlPanel.ActiveCharacterPanel.transform;
+
+        root.parent = parent;
+        button.transform.parent = parent;
+        button.gameObject.SetActive(true);
+
+        #region Abilities
+
+        for (var index = 0; index < AttributeDefinitions.AbilityScoreNames.Length; ++index)
+        {
+            var attribute = character.GetAttribute(AttributeDefinitions.AbilityScoreNames[index]);
+            abilities.abilityScoreBoxes[index].Bind(attribute, abilities.abilityScoreBoxes);
+        }
+
+        #endregion
+
+        #region Stats
+
+        stats.guiCharacter = guiCharacter;
+
+        stats.initiativeBox.Bind(character.GetAttribute(AttributeDefinitions.Initiative), "+0;-#");
+        stats.initiativeBox.Activate(true);
+
+        var proficiencyBonus = character.GetAttribute(AttributeDefinitions.ProficiencyBonus);
+        stats.proficiencyBox.Activate(proficiencyBonus != null);
+        if (stats.proficiencyBox.Activated)
+        {
+            stats.proficiencyBox.Bind(proficiencyBonus, "+0;-#");
+        }
+
+        stats.armorClassBox.Activate(proficiencyBonus != null);
+        stats.armorClassBox.gameObject.SetActive(false);
+        stats.hitDiceBox.Activate(proficiencyBonus != null);
+        stats.hitDiceBox.gameObject.SetActive(false);
+        stats.hitPointBox.Activate(proficiencyBonus != null);
+        stats.hitPointBox.gameObject.SetActive(false);
+
+        #endregion
+
+        bound = true;
+
+        Refresh();
+        UpdateVisibility();
+    }
+
+    public void Unbind()
+    {
+        bound = false;
+        root.gameObject.SetActive(false);
+        button.gameObject.SetActive(false);
+        character = null;
+        guiCharacter = null;
+
+        #region Abilities
+
+        abilities.Unbind();
+
+        #endregion
+
+        #region Stats
+
+        stats.Unbind();
+        stats.initiativeBox.Unbind();
+        stats.moveBox.Unbind();
+        stats.proficiencyBox.Unbind();
+
+        #endregion
+
+        #region Attacks
+
+        attacks.Unbind();
+
+        #endregion
+    }
+
+    public void Refresh()
+    {
+        if (!bound || character == null || guiCharacter == null)
+        {
+            return;
+        }
+
+        #region Stats
+
+        stats.initiativeBox.Refresh();
+        stats.moveBox.ValueLabel.Text = guiCharacter.MovePoints;
+        stats.proficiencyBox.Refresh();
+
+        #endregion
+
+        #region Attacks
+
+        //refresh
+
+        attacks.relevantAttackModes.Clear();
+        attacks.relevantAttackModes.AddRange(character.AttackModes
+            .Where(m => m.ActionType is ActionDefinitions.ActionType.Main or ActionDefinitions.ActionType.Bonus));
+
+        while (attacks.attackModesTable.childCount < attacks.relevantAttackModes.Count)
+        {
+            Gui.GetPrefabFromPool(attacks.attackModePrefab, attacks.attackModesTable);
+        }
+
+        for (var index = 0; index < attacks.attackModesTable.childCount; ++index)
+        {
+            var child = attacks.attackModesTable.GetChild(index);
+            if (index < attacks.relevantAttackModes.Count)
+            {
+                child.gameObject.SetActive(true);
+                child.GetComponent<AttackModeBox>().Bind(attacks.relevantAttackModes[index]);
+            }
+            else
+            {
+                child.GetComponent<AttackModeBox>().Unbind();
+                child.gameObject.SetActive(false);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
@@ -1,4 +1,5 @@
 ﻿using SolastaUnfinishedBusiness.Api.ModKit;
+using SolastaUnfinishedBusiness.CustomUI;
 using SolastaUnfinishedBusiness.Models;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ internal static class GameUiDisplay
 {
     private static bool _selectedForSwap;
     private static int _selectedX, _selectedY;
-    private static readonly string[] SetNames = { "1", "2", "3", "4", "5" };
+    private static readonly string[] SetNames = {"1", "2", "3", "4", "5"};
 
     private static void DisplayFormationGrid()
     {
@@ -369,6 +370,19 @@ internal static class GameUiDisplay
         if (UI.Toggle(Gui.Localize("ModUi/&RemoveBugVisualModels"), ref toggle, UI.AutoWidth()))
         {
             Main.Settings.RemoveBugVisualModels = toggle;
+        }
+
+        if (Main.Settings.EnableBetaContent)
+        {
+            toggle = Main.Settings.ShowButtonWithControlledMonsterInfo;
+            if (UI.Toggle(Gui.Localize("ModUi/&ShowButtonWithControlledMonsterInfo"), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.ShowButtonWithControlledMonsterInfo = toggle;
+                if (!toggle)
+                {
+                    CustomCharacterStatsPanel.MaybeInstance?.Unbind();
+                }
+            }
         }
 
         #endregion

--- a/SolastaUnfinishedBusiness/FightingStyles/Pugilist.cs
+++ b/SolastaUnfinishedBusiness/FightingStyles/Pugilist.cs
@@ -52,8 +52,9 @@ internal sealed class Pugilist : AbstractFightingStyle
                 return;
             }
 
-            var additionalDice = EffectFormBuilder.Create()
-                .SetDamageForm(DamageTypeBludgeoning, 1, DieType.D4)
+            var additionalDice = EffectFormBuilder
+                .Create()
+                .SetDamageForm(damage.damageType, 1, DieType.D4)
                 .Build();
 
             effectDescription.EffectForms.Insert(k + 1, additionalDice);

--- a/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
@@ -123,6 +123,7 @@ internal static class SrdAndHouseRulesContext
         DistantHandMartialArtsDie();
         FixTwinnedMetamagic();
         FixAttackBuffsAffectingSpellDamamge();
+        FixMissingWildShapeTagOnSomeForms();
     }
 
     internal static void ModifyAttackModeAndDamage(
@@ -593,6 +594,16 @@ internal static class SrdAndHouseRulesContext
         //BUGFIX: fix Divine Favor applying bonus damage to spells
         FeatureDefinitionAdditionalDamages.AdditionalDamageDivineFavor
             .AddCustomSubFeatures(ValidatorsRestrictedContext.WeaponAttack);
+    }
+
+    private static void FixMissingWildShapeTagOnSomeForms()
+    {
+        //BUGFIX: fix some Wild Shape forms missing proper tag, making wild shape action button visible while wild-shaped
+        var wildShape = FeatureDefinitionPowers.PowerDruidWildShape;
+        foreach (var option in wildShape.EffectDescription.FindFirstShapeChangeForm().ShapeOptions)
+        {
+            option.substituteMonster.CreatureTags.TryAdd(TagsDefinitions.CreatureTagWildShape);
+        }
     }
 
     internal static void SwitchEnableUpcastConjureElementalAndFey()

--- a/SolastaUnfinishedBusiness/Patches/ActiveCharacterPanelPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/ActiveCharacterPanelPatcher.cs
@@ -18,9 +18,12 @@ public static class ActiveCharacterPanelPatcher
         {
             //PATCH: support for custom point pools and concentration powers on portrait
             IconsOnPortrait.CharacterPanelRefresh(__instance);
-            
+
             //PATCH: support for button that shows info about non-Hero characters
-            CustomCharacterStatsPanel.Instance.Refresh();
+            if (Main.Settings.ShowButtonWithControlledMonsterInfo)
+            {
+                CustomCharacterStatsPanel.Instance.Refresh();
+            }
         }
     }
 
@@ -33,7 +36,8 @@ public static class ActiveCharacterPanelPatcher
         public static void Postfix(ActiveCharacterPanel __instance)
         {
             //PATCH: support for button that shows info about non-Hero characters
-            if (__instance.GuiCharacter.RulesetCharacter is not RulesetCharacterMonster)
+            if (!Main.Settings.ShowButtonWithControlledMonsterInfo
+                || __instance.GuiCharacter.RulesetCharacter is not RulesetCharacterMonster)
             {
                 return;
             }
@@ -41,7 +45,7 @@ public static class ActiveCharacterPanelPatcher
             CustomCharacterStatsPanel.Instance.Bind(__instance.GuiCharacter.RulesetCharacter);
         }
     }
-    
+
     [HarmonyPatch(typeof(ActiveCharacterPanel), nameof(ActiveCharacterPanel.Unbind))]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     [UsedImplicitly]
@@ -51,7 +55,10 @@ public static class ActiveCharacterPanelPatcher
         public static void Postfix()
         {
             //PATCH: support for button that shows info about non-Hero characters
-            CustomCharacterStatsPanel.Instance.Unbind();
+            if (Main.Settings.ShowButtonWithControlledMonsterInfo)
+            {
+                CustomCharacterStatsPanel.Instance.Unbind();
+            }
         }
     }
 }

--- a/SolastaUnfinishedBusiness/Patches/ActiveCharacterPanelPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/ActiveCharacterPanelPatcher.cs
@@ -18,6 +18,40 @@ public static class ActiveCharacterPanelPatcher
         {
             //PATCH: support for custom point pools and concentration powers on portrait
             IconsOnPortrait.CharacterPanelRefresh(__instance);
+            
+            //PATCH: support for button that shows info about non-Hero characters
+            CustomCharacterStatsPanel.Instance.Refresh();
+        }
+    }
+
+    [HarmonyPatch(typeof(ActiveCharacterPanel), nameof(ActiveCharacterPanel.Bind))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class Bind_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(ActiveCharacterPanel __instance)
+        {
+            //PATCH: support for button that shows info about non-Hero characters
+            if (__instance.GuiCharacter.RulesetCharacter is not RulesetCharacterMonster)
+            {
+                return;
+            }
+
+            CustomCharacterStatsPanel.Instance.Bind(__instance.GuiCharacter.RulesetCharacter);
+        }
+    }
+    
+    [HarmonyPatch(typeof(ActiveCharacterPanel), nameof(ActiveCharacterPanel.Unbind))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class Unbind_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix()
+        {
+            //PATCH: support for button that shows info about non-Hero characters
+            CustomCharacterStatsPanel.Instance.Unbind();
         }
     }
 }

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -17,6 +17,7 @@ public sealed class Core
 public class Settings : UnityModManager.ModSettings
 {
     private bool enumerateOriginSubFeatures;
+    private bool showButtonWithControlledMonsterInfo;
     //
     // UI Saved State
     //
@@ -320,6 +321,12 @@ public class Settings : UnityModManager.ModSettings
     // Monsters
     public bool HideMonsterHitPoints { get; set; }
     public bool RemoveBugVisualModels { get; set; }
+    
+    public bool ShowButtonWithControlledMonsterInfo
+    {
+        get => showButtonWithControlledMonsterInfo && EnableBetaContent;
+        set => showButtonWithControlledMonsterInfo = value;
+    }
 
     //
     // Interface - Dungeon Maker

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -192,6 +192,7 @@ ModUi/&SettingsLoad=. Load an exported setting
 ModUi/&SettingsOpenFolder=Open exported settings folder
 ModUi/&SettingsRefresh=Refresh
 ModUi/&SettingsRemove=Remove
+ModUi/&ShowButtonWithControlledMonsterInfo=<b><color=#C04040E0>[BETA]</color></b> Show button that opens info about controlled monster <i><color=#F0DAA0>[wild-shaped druids, summons, NPC followers, etc.]</color></i>
 ModUi/&ShowChannelDivinityOnPortrait=Show how many <color=#D89555>Channel Divinity</color> uses a hero has on their portrait, similar to sorcery points
 ModUi/&ShowCraftedItemOnRecipeIcon=Show crafted item icon near recipe item in shop and inventory. Hovering over it will show tooltip for crafted item
 ModUi/&ShowCraftingRecipeInDetailedTooltips=Show crafting recipe in detailed tooltips


### PR DESCRIPTION
- added beta setting `Interface => Game UI => Monsters` to enable monster info button that shows info about current non-Hero character (wild-shaped druid, summons, follower NPC)
- reverted Pugilist change to bonus damage type
- fixed some Wild Shape forms missing proper tag, making wild shape action button visible while wild-shaped