### PR TITLE
Even more wildshape tweaks

### DIFF
--- a/SolastaUnfinishedBusiness/Api/Extensions/RulesetCharacterExtensions.cs
+++ b/SolastaUnfinishedBusiness/Api/Extensions/RulesetCharacterExtensions.cs
@@ -469,4 +469,39 @@ internal static class RulesetCharacterExtensions
 
         rulesetCharacter.ToggledPowersOn.Remove(toggleName);
     }
+
+    internal static RulesetAttackMode TryRefreshAttackMode(
+        this RulesetCharacter character,
+        ActionType actionType,
+        ItemDefinition itemDefinition,
+        WeaponDescription weaponDescription,
+        bool freeOffHand,
+        bool canAddAbilityDamageBonus,
+        string slotName,
+        List<IAttackModificationProvider> attackModifiers,
+        Dictionary<FeatureDefinition, FeatureOrigin> featuresOrigin,
+        RulesetItem weapon = null)
+    {
+        return character switch
+        {
+            RulesetCharacterHero hero => hero.RefreshAttackMode(
+                actionType,
+                itemDefinition,
+                weaponDescription,
+                freeOffHand,
+                canAddAbilityDamageBonus,
+                slotName,
+                attackModifiers,
+                featuresOrigin,
+                weapon),
+            RulesetCharacterMonster monster => monster.RefreshAttackMode(
+                actionType,
+                itemDefinition,
+                weaponDescription,
+                canAddAbilityDamageBonus,
+                attackModifiers,
+                featuresOrigin),
+            _ => null
+        };
+    }
 }

--- a/SolastaUnfinishedBusiness/Api/Extensions/RulesetCharacterMonsterExtensions.cs
+++ b/SolastaUnfinishedBusiness/Api/Extensions/RulesetCharacterMonsterExtensions.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using static RuleDefinitions;
+
+namespace SolastaUnfinishedBusiness.Api.Extensions;
+
+public static class RulesetCharacterMonsterExtensions
+{
+    public static RulesetAttackMode RefreshAttackMode(
+        this RulesetCharacterMonster monster,
+        ActionDefinitions.ActionType actionType,
+        ItemDefinition itemDefinition,
+        WeaponDescription weaponDescription,
+        bool canAddAbilityDamageBonus,
+        List<IAttackModificationProvider> attackModifiers,
+        Dictionary<FeatureDefinition, FeatureOrigin> featuresOrigin
+    )
+    {
+        var slotName = EquipmentDefinitions.SlotTypeMainHand;
+        var hero = monster.OriginalFormCharacter as RulesetCharacterHero;
+
+        var attackMode = RulesetAttackMode.AttackModesPool.Get();
+        attackMode.Clear();
+        attackMode.FreeOffHand = true;
+        attackMode.ActionType = actionType;
+        attackMode.SourceDefinition = itemDefinition;
+        attackMode.SlotName = slotName;
+        attackMode.SourceObject = null;
+        if (actionType == ActionDefinitions.ActionType.Main)
+        {
+            attackMode.AttacksNumber = monster.GetAttribute(AttributeDefinitions.AttacksNumber).CurrentValue;
+        }
+
+        var weaponType = DatabaseRepository.GetDatabase<WeaponTypeDefinition>()
+            .GetElement(weaponDescription.WeaponType);
+        attackMode.AbilityScore = weaponType.WeaponProximity == AttackProximity.Melee
+            ? AttributeDefinitions.Strength
+            : AttributeDefinitions.Dexterity;
+
+        var dexterity = monster.TryGetAttributeValue(AttributeDefinitions.Dexterity);
+        var strength = monster.TryGetAttributeValue(AttributeDefinitions.Strength);
+        
+        if (weaponDescription.WeaponTags.Contains(TagsDefinitions.WeaponTagFinesse))
+        {
+            if (dexterity > strength)
+            {
+                attackMode.AbilityScore = AttributeDefinitions.Dexterity;
+            }
+            else if (strength > dexterity)
+            {
+                attackMode.AbilityScore = AttributeDefinitions.Strength;
+            }
+        }
+
+        attackMode.Ranged = weaponType.WeaponProximity == AttackProximity.Range;
+        attackMode.Thrown = weaponDescription.WeaponTags.Contains(TagsDefinitions.WeaponTagThrown);
+        attackMode.Reach = weaponDescription.WeaponTags.Contains(TagsDefinitions.WeaponTagReach);
+        attackMode.ReachRange = attackMode.Reach ? weaponDescription.ReachRange : 1;
+        if (attackMode.Ranged || attackMode.Thrown)
+        {
+            attackMode.CloseRange = weaponDescription.CloseRange;
+            attackMode.MaxRange = weaponDescription.MaxRange;
+        }
+
+        if (monster.IsProficientWithItem(itemDefinition) || (hero != null && hero.IsProficientWithItem(itemDefinition)))
+        {
+            var currentValue = monster.TryGetAttributeValue(AttributeDefinitions.ProficiencyBonus);
+            attackMode.ToHitBonus += currentValue;
+            attackMode.ToHitBonusTrends.Add(new TrendInfo(currentValue,
+                FeatureSourceType.Proficiency, string.Empty, null));
+        }
+
+        attackMode.EffectDescription.Copy(weaponDescription.EffectDescription);
+        attackMode.UseVersatileDamage =
+            weaponDescription.WeaponTags.Contains(TagsDefinitions.WeaponTagVersatile) & true;
+        foreach (var itemTag in itemDefinition.ItemTags)
+        {
+            attackMode.AddAttackTagAsNeeded(itemTag);
+        }
+
+        var service = ServiceRepository.GetService<IRulesetImplementationService>();
+        foreach (var attackModifier in attackModifiers)
+        {
+            if (attackModifier == null)
+            {
+                Trace.LogException(new Exception("[Tactical - Invisible for players] attackModifier is null"));
+            }
+            else if (hero != null && service.IsValidContextForAttackModificationProvider(attackModifier, hero,
+                         itemDefinition, weaponType, attackMode))
+            {
+                if (attackModifier.MagicalWeapon)
+                {
+                    attackMode.AddAttackTagAsNeeded(TagsDefinitions.MagicalWeapon);
+                }
+
+                var attackRollModifier = attackModifier.AttackRollModifier;
+                attackMode.ToHitBonus += attackRollModifier;
+                var key = attackModifier as FeatureDefinition;
+                if (key != null && featuresOrigin.TryGetValue(key, out var value))
+                {
+                    attackMode.ToHitBonusTrends.Add(new TrendInfo(attackRollModifier, value.sourceType,
+                        featuresOrigin[key].sourceName, featuresOrigin[key].source));
+                }
+
+                if (attackModifier.AbilityScoreReplacement == AbilityScoreReplacement.DexterityIfBetterThanStrength)
+                {
+                    if (dexterity >= strength)
+                    {
+                        attackMode.AbilityScore = AttributeDefinitions.Dexterity;
+                    }
+                    else if (strength > dexterity)
+                    {
+                        attackMode.AbilityScore = AttributeDefinitions.Strength;
+                    }
+                }
+
+                if (attackModifier.DamageDieReplacement != DamageDieReplacement.None)
+                {
+                    var firstDamageForm = attackMode.EffectDescription.FindFirstDamageForm();
+                    if (firstDamageForm != null)
+                    {
+                        switch (attackModifier.DamageDieReplacement)
+                        {
+                            case DamageDieReplacement.FirstDamageForm:
+                                firstDamageForm.DieType = attackModifier.ReplacedDieType;
+                                if (firstDamageForm.VersatileDieType < attackModifier.ReplacedDieType)
+                                {
+                                    firstDamageForm.VersatileDieType = attackModifier.ReplacedDieType;
+                                }
+
+                                break;
+                            case DamageDieReplacement.DieTypeByRankIfBetterThanNatural:
+                                hero.UpgradeAttackModeDieTypeWithAttackModifierByCharacterLevel(attackMode,
+                                    attackModifier);
+                                break;
+                        }
+                    }
+                }
+
+                if (attackModifier.AdditionalEffectForms == null)
+                {
+                    continue;
+                }
+
+                foreach (var additionalEffectForm in attackModifier.AdditionalEffectForms)
+                {
+                    attackMode.EffectDescription.EffectForms.Add(EffectForm.GetCopy(additionalEffectForm));
+                }
+            }
+        }
+
+        var abilityScoreModifier =
+            AttributeDefinitions.ComputeAbilityScoreModifier(monster.Attributes[attackMode.AbilityScore].CurrentValue);
+        
+        attackMode.ToHitBonus += abilityScoreModifier;
+        attackMode.ToHitBonusTrends.Add(new TrendInfo(abilityScoreModifier,
+            FeatureSourceType.AbilityScore, attackMode.AbilityScore, null));
+        var firstDamageForm1 = attackMode.EffectDescription.FindFirstDamageForm();
+        if (firstDamageForm1 != null)
+        {
+            firstDamageForm1.DamageBonusTrends.Clear();
+            if (canAddAbilityDamageBonus)
+            {
+                firstDamageForm1.BonusDamage += abilityScoreModifier;
+                firstDamageForm1.DamageBonusTrends.Add(new TrendInfo(abilityScoreModifier,
+                    FeatureSourceType.AbilityScore, attackMode.AbilityScore, null));
+            }
+
+            foreach (var attackModifier in attackModifiers)
+            {
+                if (attackModifier == null)
+                {
+                    Trace.LogException(new Exception("[Tactical - Invisible for players] attackModifier is null"));
+                }
+                else if (hero != null
+                         && service.IsValidContextForAttackModificationProvider(attackModifier, hero, itemDefinition,
+                             weaponType, attackMode)
+                         && attackModifier.DamageRollModifierMethod != AttackModifierMethod.None)
+                {
+                    var num = attackModifier.DamageRollModifier;
+                    if (attackModifier.DamageRollModifierMethod == AttackModifierMethod.SourceConditionAmount)
+                    {
+                        num = monster.FindFirstConditionHoldingFeature(attackModifier as FeatureDefinition).Amount;
+                    }
+                    else if (attackModifier.DamageRollModifierMethod == AttackModifierMethod.AddAbilityScoreBonus
+                             && !string.IsNullOrEmpty(attackModifier.DamageRollAbilityScore))
+                    {
+                        num += AttributeDefinitions.ComputeAbilityScoreModifier(
+                            monster.TryGetAttributeValue(attackModifier.DamageRollAbilityScore));
+                    }
+
+                    firstDamageForm1.BonusDamage += num;
+                    var key = attackModifier as FeatureDefinition;
+                    if (key != null && featuresOrigin.TryGetValue(key, out var value))
+                    {
+                        firstDamageForm1.DamageBonusTrends.Add(new TrendInfo(num, value.sourceType,
+                            featuresOrigin[key].sourceName, featuresOrigin[key].source));
+                    }
+                }
+            }
+        }
+
+        return attackMode;
+    }
+}

--- a/SolastaUnfinishedBusiness/Classes/Inventor/Subclasses/InnovationArmor.cs
+++ b/SolastaUnfinishedBusiness/Classes/Inventor/Subclasses/InnovationArmor.cs
@@ -288,8 +288,12 @@ public static class InnovationArmor
         {
         }
 
-        protected override List<RulesetAttackMode> GetAttackModes(RulesetCharacterHero hero)
+        protected override List<RulesetAttackMode> GetAttackModes(RulesetCharacter character)
         {
+            if (character is not RulesetCharacterHero hero)
+            {
+                return null;
+            }
             var strikeDefinition = CustomWeaponsContext.ThunderGauntlet;
 
             var attackModifiers = hero.attackModifiers;
@@ -349,9 +353,11 @@ public static class InnovationArmor
             return modes;
         }
 
-        protected override AttackModeOrder GetOrder(RulesetCharacterHero hero)
+        protected override AttackModeOrder GetOrder(RulesetCharacter character)
         {
-            return hero.HasEmptyMainHand() ? AttackModeOrder.Start : base.GetOrder(hero);
+            return (character is RulesetCharacterHero hero && hero.HasEmptyMainHand()) 
+                ? AttackModeOrder.Start 
+                : base.GetOrder(character);
         }
     }
 
@@ -362,8 +368,12 @@ public static class InnovationArmor
         {
         }
 
-        protected override List<RulesetAttackMode> GetAttackModes(RulesetCharacterHero hero)
+        protected override List<RulesetAttackMode> GetAttackModes(RulesetCharacter character)
         {
+            if (character is not RulesetCharacterHero hero)
+            {
+                return null;
+            }
             var strikeDefinition = CustomWeaponsContext.LightningLauncher;
             var attackModifiers = hero.attackModifiers;
             var attackMode = hero.RefreshAttackMode(

--- a/SolastaUnfinishedBusiness/Classes/Inventor/Subclasses/InnovationArmor.cs
+++ b/SolastaUnfinishedBusiness/Classes/Inventor/Subclasses/InnovationArmor.cs
@@ -283,7 +283,7 @@ public static class InnovationArmor
 
     private class AddGauntletAttack : AddExtraAttackBase
     {
-        public AddGauntletAttack() : base(ActionDefinitions.ActionType.Main, false, InGuardianMode,
+        public AddGauntletAttack() : base(ActionDefinitions.ActionType.Main, InGuardianMode,
             ValidatorsCharacter.HasFreeHand)
         {
         }
@@ -358,7 +358,7 @@ public static class InnovationArmor
 
     private class AddLauncherAttack : AddExtraAttackBase
     {
-        public AddLauncherAttack() : base(ActionDefinitions.ActionType.Main, false, InInfiltratorMode)
+        public AddLauncherAttack() : base(ActionDefinitions.ActionType.Main, InInfiltratorMode)
         {
         }
 

--- a/SolastaUnfinishedBusiness/CustomBehaviors/AddExtraAttack.cs
+++ b/SolastaUnfinishedBusiness/CustomBehaviors/AddExtraAttack.cs
@@ -19,50 +19,26 @@ internal abstract class AddExtraAttackBase : IAddExtraAttack
     protected readonly ActionDefinitions.ActionType ActionType;
 
     // private readonly List<string> additionalTags = new();
-    private readonly bool clearSameType;
     private readonly IsCharacterValidHandler[] validators;
 
     protected AddExtraAttackBase(
         ActionDefinitions.ActionType actionType,
-        bool clearSameType,
         params IsCharacterValidHandler[] validators)
     {
         ActionType = actionType;
-        this.clearSameType = clearSameType;
         this.validators = validators;
     }
 
-    protected AddExtraAttackBase(
-        ActionDefinitions.ActionType actionType,
-        params IsCharacterValidHandler[] validators) :
-        this(actionType, false, validators)
+    public void TryAddExtraAttack(RulesetCharacter character)
     {
-    }
+        var hero = character as RulesetCharacterHero ?? character.OriginalFormCharacter as RulesetCharacterHero;
 
-    public void TryAddExtraAttack(RulesetCharacterHero hero)
-    {
-        if (!hero.IsValid(validators))
+        if (hero == null || !hero.IsValid(validators))
         {
             return;
         }
 
-        var attackModes = hero.AttackModes;
-
-        if (clearSameType)
-        {
-            for (var i = attackModes.Count - 1; i > 0; i--)
-            {
-                var mode = attackModes[i];
-
-                if (mode.ActionType != ActionType)
-                {
-                    continue;
-                }
-
-                RulesetAttackMode.AttackModesPool.Return(mode);
-                attackModes.RemoveAt(i);
-            }
-        }
+        var attackModes = character.AttackModes;
 
         var newAttacks = GetAttackModes(hero);
 
@@ -217,8 +193,7 @@ internal sealed class AddExtraMainHandAttack : AddExtraAttackBase
 {
     internal AddExtraMainHandAttack(
         ActionDefinitions.ActionType actionType,
-        bool clearSameType,
-        params IsCharacterValidHandler[] validators) : base(actionType, clearSameType, validators)
+        params IsCharacterValidHandler[] validators) : base(actionType, validators)
     {
         // Empty
     }
@@ -315,8 +290,8 @@ internal sealed class AddExtraRangedAttack : AddExtraAttackBase
 
 internal sealed class AddPolearmFollowupAttack : AddExtraAttackBase
 {
-    internal AddPolearmFollowupAttack() : base(ActionDefinitions.ActionType.Bonus, false,
-        ValidatorsCharacter.HasAttacked, ValidatorsCharacter.HasPolearm)
+    internal AddPolearmFollowupAttack() : base(ActionDefinitions.ActionType.Bonus, ValidatorsCharacter.HasAttacked,
+        ValidatorsCharacter.HasPolearm)
     {
         // Empty
     }
@@ -382,7 +357,7 @@ internal sealed class AddPolearmFollowupAttack : AddExtraAttackBase
 
 internal sealed class AddBonusShieldAttack : AddExtraAttackBase
 {
-    internal AddBonusShieldAttack() : base(ActionDefinitions.ActionType.Bonus, false)
+    internal AddBonusShieldAttack() : base(ActionDefinitions.ActionType.Bonus)
     {
         // Empty
     }
@@ -455,7 +430,7 @@ internal sealed class AddBonusTorchAttack : AddExtraAttackBase
 {
     private readonly FeatureDefinitionPower torchPower;
 
-    internal AddBonusTorchAttack(FeatureDefinitionPower torchPower) : base(ActionDefinitions.ActionType.Bonus, false)
+    internal AddBonusTorchAttack(FeatureDefinitionPower torchPower) : base(ActionDefinitions.ActionType.Bonus)
     {
         this.torchPower = torchPower;
     }

--- a/SolastaUnfinishedBusiness/CustomInterfaces/IAddExtraAttack.cs
+++ b/SolastaUnfinishedBusiness/CustomInterfaces/IAddExtraAttack.cs
@@ -2,5 +2,5 @@
 
 public interface IAddExtraAttack
 {
-    public void TryAddExtraAttack(RulesetCharacterHero hero);
+    public void TryAddExtraAttack(RulesetCharacter character);
 }

--- a/SolastaUnfinishedBusiness/Models/CustomWeaponsContext.cs
+++ b/SolastaUnfinishedBusiness/Models/CustomWeaponsContext.cs
@@ -854,9 +854,12 @@ internal sealed class AddThrowProducedFlameAttack : AddExtraAttackBase
     {
     }
 
-    [NotNull]
-    protected override List<RulesetAttackMode> GetAttackModes([NotNull] RulesetCharacterHero hero)
+    protected override List<RulesetAttackMode> GetAttackModes([NotNull] RulesetCharacter character)
     {
+        if (character is not RulesetCharacterHero hero)
+        {
+            return null;
+        }
         var result = new List<RulesetAttackMode>();
         AddItemAttack(result, EquipmentDefinitions.SlotTypeMainHand, hero);
         AddItemAttack(result, EquipmentDefinitions.SlotTypeOffHand, hero);

--- a/SolastaUnfinishedBusiness/Models/CustomWeaponsContext.cs
+++ b/SolastaUnfinishedBusiness/Models/CustomWeaponsContext.cs
@@ -850,7 +850,7 @@ internal sealed class ModifyProducedFlameDice : ModifyAttackModeForWeaponBase
 
 internal sealed class AddThrowProducedFlameAttack : AddExtraAttackBase
 {
-    internal AddThrowProducedFlameAttack() : base(ActionDefinitions.ActionType.Main, false)
+    internal AddThrowProducedFlameAttack() : base(ActionDefinitions.ActionType.Main)
     {
     }
 

--- a/SolastaUnfinishedBusiness/Models/MulticlassWildshapeContext.cs
+++ b/SolastaUnfinishedBusiness/Models/MulticlassWildshapeContext.cs
@@ -88,9 +88,8 @@ internal static class MulticlassWildshapeContext
             {
                 var strikeDefinition = hero.UnarmedStrikeDefinition;
 
-                bonusUnarmedAttack = hero.RefreshAttackMode(ActionType.Bonus, strikeDefinition,
-                    strikeDefinition.WeaponDescription, true, true, EquipmentDefinitions.SlotTypeMainHand,
-                    monster.attackModifiers, monster.FeaturesOrigin);
+                bonusUnarmedAttack = monster.RefreshAttackMode(ActionType.Bonus, strikeDefinition,
+                    strikeDefinition.WeaponDescription, true, monster.attackModifiers, monster.FeaturesOrigin);
                 bonusUnarmedAttack.AttacksNumber = attackModifier.AdditionalBonusUnarmedStrikeAttacksCount;
                 if (!string.IsNullOrEmpty(attackModifier.AdditionalBonusUnarmedStrikeAttacksTag))
                 {

--- a/SolastaUnfinishedBusiness/Patches/RulesetCharacterMonsterPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetCharacterMonsterPatcher.cs
@@ -141,6 +141,9 @@ public static class RulesetCharacterMonsterPatcher
         [UsedImplicitly]
         public static void Postfix(RulesetCharacterMonster __instance)
         {
+            //PATCH: allow monk bonus unarmed attacks on wild-shaped characters
+            MulticlassWildshapeContext.HandleExtraUnarmedAttacks(__instance);
+            
             //PATCH: Allows changing damage and other stats of an attack mode
             var modifiers = __instance.GetSubFeaturesByType<IModifyAttackModeForWeapon>();
 
@@ -172,6 +175,28 @@ public static class RulesetCharacterMonsterPatcher
         {
             //PATCH: INotifyConditionRemoval, keep a tab on all monster conditions before death
             ConditionsBeforeDeath.SetRange(__instance.AllConditions.ToList());
+        }
+    }
+    
+    [HarmonyPatch(typeof(RulesetCharacterMonster), nameof(RulesetCharacterMonster.GetRemainingAttackUses))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class GetRemainingAttackUses_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(RulesetCharacterMonster __instance, ref int __result, RulesetAttackMode mode)
+        {
+            //PATCH: allow monk bonus unarmed attacks on wild-shaped characters
+            if (mode == null || __instance.OriginalFormCharacter is not RulesetCharacterHero)
+            {
+                return;
+            }
+
+            int attackModeRank = __instance.GetAttackModeRank(mode);
+            if (attackModeRank == -1 && mode.ActionType == ActionDefinitions.ActionType.Bonus)
+            {
+                __result = -1;
+            }
         }
     }
 }

--- a/SolastaUnfinishedBusiness/Patches/RulesetCharacterMonsterPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetCharacterMonsterPatcher.cs
@@ -144,6 +144,10 @@ public static class RulesetCharacterMonsterPatcher
             //PATCH: allow monk bonus unarmed attacks on wild-shaped characters
             MulticlassWildshapeContext.HandleExtraUnarmedAttacks(__instance);
             
+            //PATCH: Allows adding extra attack modes
+            __instance.GetSubFeaturesByType<IAddExtraAttack>()
+                .ForEach(provider => provider.TryAddExtraAttack(__instance));
+            
             //PATCH: Allows changing damage and other stats of an attack mode
             var modifiers = __instance.GetSubFeaturesByType<IModifyAttackModeForWeapon>();
 

--- a/SolastaUnfinishedBusiness/Patches/RulesetCharacterPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetCharacterPatcher.cs
@@ -55,6 +55,24 @@ public static class RulesetCharacterPatcher
                 null, definition.ParseSpecialFeatureTags()));
         }
     }
+    
+    [HarmonyPatch(typeof(RulesetCharacter), nameof(RulesetCharacter.IsWieldingMonkWeapon))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class IsWieldingMonkWeapon_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(RulesetCharacter __instance, ref bool __result)
+        {
+            //PATCH: count wild-shaped heros with monk classes as wielding monk weapons
+            if (__instance is not RulesetCharacterMonster || __instance.OriginalFormCharacter is not RulesetCharacterHero hero)
+            {
+                return;
+            }
+
+            __result = hero.GetClassLevel(Monk) > 0;
+        }
+    }
 
     [HarmonyPatch(typeof(RulesetCharacter), nameof(RulesetCharacter.TerminateMatchingUniquePower))]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
@@ -91,9 +109,6 @@ public static class RulesetCharacterPatcher
         public static void Postfix(RulesetCharacter __instance, RulesetCondition activeCondition)
         {
             var definition = activeCondition.ConditionDefinition;
-
-            //PATCH: allow flurry of blows to correctly work with druid under wildshape
-            MulticlassWildshapeContext.HandleFlurryOfBlows(__instance, definition);
 
             //PATCH: notifies custom condition features that condition is applied
             definition.GetAllSubFeaturesOfType<ICustomConditionFeature>()

--- a/SolastaUnfinishedBusiness/Subclasses/WayOfTheDistantHand.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/WayOfTheDistantHand.cs
@@ -360,7 +360,7 @@ internal sealed class WayOfTheDistantHand : AbstractSubclass
     internal override FeatureDefinitionSubclassChoice SubclassChoice =>
         FeatureDefinitionSubclassChoices.SubclassChoiceMonkMonasticTraditions;
 
-    internal override DeityDefinition DeityDefinition { get; }
+    internal override DeityDefinition DeityDefinition => null;
 
     private static bool IsMonkWeapon(RulesetAttackMode attackMode, RulesetItem weapon, RulesetCharacter character)
     {
@@ -500,13 +500,17 @@ internal sealed class WayOfTheDistantHand : AbstractSubclass
 
         public static AddFlurryOfArrowsAttacks Mark { get; } = new();
 
-        protected override AttackModeOrder GetOrder(RulesetCharacterHero hero)
+        protected override AttackModeOrder GetOrder(RulesetCharacter character)
         {
             return AttackModeOrder.Start;
         }
 
-        protected override List<RulesetAttackMode> GetAttackModes(RulesetCharacterHero hero)
+        protected override List<RulesetAttackMode> GetAttackModes(RulesetCharacter character)
         {
+            if (character is not RulesetCharacterHero hero)
+            {
+                return null;
+            }
             var mainHandItem = hero.CharacterInventory.InventorySlotsByName[EquipmentDefinitions.SlotTypeMainHand]
                 .EquipedItem;
 

--- a/SolastaUnfinishedBusiness/Subclasses/_CommonBuilders.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/_CommonBuilders.cs
@@ -87,7 +87,7 @@ internal static class CommonBuilders
                             .SetGuiPresentation("PowerCasterFightingWarMagic", Category.Feature)
                             .SetDamageRollModifier(1)
                             .SetCustomSubFeatures(
-                                new AddExtraMainHandAttack(ActionDefinitions.ActionType.Bonus, false))
+                                new AddExtraMainHandAttack(ActionDefinitions.ActionType.Bonus))
                             .AddToDB())
                         .AddToDB(),
                     ConditionForm.ConditionOperation.Add)


### PR DESCRIPTION
- removed change that refreshed main attack of wild-shaped hero when Flurry of Blows was used
- added support for monk's bonus unarmed attacks (including from Flurry of Blows) to wild-shaped heroes
- added support for custom extra attack features to wild-shaped heroes

closes #2619 