### PR TITLE
Fix exit tooltip

### DIFF
--- a/SolastaUnfinishedBusiness/Patches/MapGadgetItemPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/MapGadgetItemPatcher.cs
@@ -82,7 +82,12 @@ public static class MapGadgetItemPatcher
 
             var exit = Gui.Localize("Tooltip/&CustomMapMarkerExit");
             var destinations = string.Join("",
-                description.Destinations.Select(d => $"\n - {d.UserLocationName}"));
+                description.Destinations
+                    .Where(d => d is not null)
+                    .Where(d => !string.IsNullOrWhiteSpace(d.UserLocationName))
+                    .Where(d => !Gui.GameCampaign.UserLocationsStatus.ContainsKey(d.UserLocationName) || Gui.GameCampaign.UserLocationsStatus[d.UserLocationName] != LocationDefinitions.UserLocationStatus.Hidden)
+                    .Select(d => $"\n - {(string.IsNullOrWhiteSpace(d.DisplayedTitle) ? d.UserLocationName : d.DisplayedTitle)}"));
+
 
             return $"{exit}:{destinations}";
         }


### PR DESCRIPTION
The tooltip on the exit gadget 
1) incorrectly shows hidden locations
2) incorrectly shows the location name not the intended location title

I'm not sure why `!Gui.GameCampaign.UserLocationsStatus.ContainsKey(d.UserLocationName)` is required but it's taken from `DestinationSelectionModel.ShowDestination` so I assume it's correct.

`.Where(d => !Gui.GameCampaign.UserLocationsStatus.ContainsKey(d.UserLocationName) || Gui.GameCampaign.UserLocationsStatus[d.UserLocationName] != LocationDefinitions.UserLocationStatus.Hidden)`

