### PR TITLE
fixed CustomInvocationSelectionPanel cleanup

### DIFF
--- a/SolastaUnfinishedBusiness/CustomUI/CustomInvocationSelectionPanel.cs
+++ b/SolastaUnfinishedBusiness/CustomUI/CustomInvocationSelectionPanel.cs
@@ -721,9 +721,6 @@ internal class CustomInvocationSelectionPanel : CharacterStagePanel
 
     public override void OnEndHide()
     {
-        // learnedInvocations.Clear();
-        // allPools.Clear();
-
         for (var i = 0; i < spellsByLevelTable.childCount; i++)
         {
             var child = spellsByLevelTable.GetChild(i);
@@ -737,9 +734,9 @@ internal class CustomInvocationSelectionPanel : CharacterStagePanel
             group.CustomUnbind();
         }
 
-        // Gui.ReleaseChildrenToPool(spellsByLevelTable);
-        // Gui.ReleaseChildrenToPool(learnStepsTable);
-        // Gui.ReleaseChildrenToPool(levelButtonsTable);
+        Gui.ReleaseChildrenToPool(spellsByLevelTable);
+        Gui.ReleaseChildrenToPool(learnStepsTable);
+        Gui.ReleaseChildrenToPool(levelButtonsTable);
 
         base.OnEndHide();
 


### PR DESCRIPTION
do release children to pools, but don't clean collected point pools and selected abilities