### PR TITLE
Align skill with stat on Squat Nimbleness

### DIFF
--- a/SolastaUnfinishedBusiness/Feats/RaceFeats.cs
+++ b/SolastaUnfinishedBusiness/Feats/RaceFeats.cs
@@ -185,9 +185,9 @@ internal static class RaceFeats
                 AttributeModifierCreed_Of_Misaye,
                 DatabaseHelper.FeatureDefinitionMovementAffinitys.MovementAffinitySixLeaguesBoots,
                 FeatureDefinitionProficiencyBuilder
-                    .Create("ProficiencyFeatSquatNimblenessAthletics")
+                    .Create("ProficiencyFeatSquatNimblenessAcrobatics")
                     .SetGuiPresentationNoContent(true)
-                    .SetProficiencies(ProficiencyType.SkillOrExpertise, DatabaseHelper.SkillDefinitions.Athletics.Name)
+                    .SetProficiencies(ProficiencyType.SkillOrExpertise, DatabaseHelper.SkillDefinitions.Acrobatics.Name)
                     .AddToDB())
             .SetValidators(ValidatorsFeat.IsSmallRace)
             .SetFeatFamily(SquatNimbleness)
@@ -200,9 +200,9 @@ internal static class RaceFeats
                 AttributeModifierCreed_Of_Einar,
                 DatabaseHelper.FeatureDefinitionMovementAffinitys.MovementAffinitySixLeaguesBoots,
                 FeatureDefinitionProficiencyBuilder
-                    .Create("ProficiencyFeatSquatNimblenessAcrobatics")
+                    .Create("ProficiencyFeatSquatNimblenessAthletics")
                     .SetGuiPresentationNoContent(true)
-                    .SetProficiencies(ProficiencyType.SkillOrExpertise, DatabaseHelper.SkillDefinitions.Acrobatics.Name)
+                    .SetProficiencies(ProficiencyType.SkillOrExpertise, DatabaseHelper.SkillDefinitions.Athletics.Name)
                     .AddToDB())
             .SetValidators(ValidatorsFeat.IsSmallRace)
             .SetFeatFamily(SquatNimbleness)


### PR DESCRIPTION
Squat Nimbleness (Str) gives Acrobatics where Squat Nimbleness (Dex) gives Athletics -- this feels like it's backwards (one would expect the Str skill to go with the Str version of the feat)

If this is intentional, reject this PR.