### PR TITLE
BUGFIX: Fix Darkness Spell interaction with Devil's Sight and similar ability

### DIFF
--- a/SolastaUnfinishedBusiness/Api/DatabaseHelper-RELEASE.cs
+++ b/SolastaUnfinishedBusiness/Api/DatabaseHelper-RELEASE.cs
@@ -1,4 +1,4 @@
-// manually generated on 04/10/23
+﻿// manually generated on 04/10/23
 using TA.AI;
 // ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
@@ -460,6 +460,7 @@ internal static partial class DatabaseHelper
         internal static FeatureDefinitionCombatAffinity CombatAffinityReckless { get; } = GetDefinition<FeatureDefinitionCombatAffinity>("CombatAffinityReckless");
         internal static FeatureDefinitionCombatAffinity CombatAffinitySensitiveToLight { get; } = GetDefinition<FeatureDefinitionCombatAffinity>("CombatAffinitySensitiveToLight");
         internal static FeatureDefinitionCombatAffinity CombatAffinityStealthy { get; } = GetDefinition<FeatureDefinitionCombatAffinity>("CombatAffinityStealthy");
+        internal static FeatureDefinitionCombatAffinity CombatAffinityVeil { get; } = GetDefinition<FeatureDefinitionCombatAffinity>("CombatAffinityVeil");
     }
     internal static class FeatureDefinitionConditionAffinitys
     {
@@ -483,6 +484,7 @@ internal static partial class DatabaseHelper
         internal static FeatureDefinitionConditionAffinity ConditionAffinityPoisonImmunity { get; } = GetDefinition<FeatureDefinitionConditionAffinity>("ConditionAffinityPoisonImmunity");
         internal static FeatureDefinitionConditionAffinity ConditionAffinityProneImmunity { get; } = GetDefinition<FeatureDefinitionConditionAffinity>("ConditionAffinityProneImmunity");
         internal static FeatureDefinitionConditionAffinity ConditionAffinityRestrainedmmunity { get; } = GetDefinition<FeatureDefinitionConditionAffinity>("ConditionAffinityRestrainedmmunity");
+        internal static FeatureDefinitionConditionAffinity ConditionAffinityInvocationDevilsSight { get; } = GetDefinition<FeatureDefinitionConditionAffinity>("ConditionAffinityInvocationDevilsSight");
     }
     internal static class FeatureDefinitionDamageAffinitys
     {

--- a/SolastaUnfinishedBusiness/Displays/RulesDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/RulesDisplay.cs
@@ -54,6 +54,7 @@ internal static class RulesDisplay
                 UI.AutoWidth()))
         {
             Main.Settings.AttackersWithDarkvisionHaveAdvantageOverDefendersWithout = toggle;
+            SrdAndHouseRulesContext.FixDarknessSpell();
         }
 
         UI.Label();

--- a/SolastaUnfinishedBusiness/Models/FixesContext.cs
+++ b/SolastaUnfinishedBusiness/Models/FixesContext.cs
@@ -38,7 +38,6 @@ internal static class FixesContext
         FixStunningStrikeForAnyMonkWeapon();
         FixTwinnedMetamagic();
         FixWildshapeGroupAttacks();
-        FixDarknessImplementation();
 
         // avoid folks tweaking max party size directly on settings as we don't need to stress cloud servers
         Main.Settings.OverridePartySize = Math.Min(Main.Settings.OverridePartySize, ToolsContext.MaxPartySize);
@@ -58,16 +57,6 @@ internal static class FixesContext
 
         ActionAffinityUncannyDodge.SetCustomSubFeatures(new ValidatorsDefinitionApplication(
             IsActionAffinityUncannyDodgeValid(RoguishDuelist.ConditionReflexiveParry)));
-    }
-
-    private static void FixDarknessImplementation()
-    {
-        //BUGFIX: Now that we have better handled sight and advantage elsewhere, darkness should no more give other source of disadvantage on attack
-        // and the immunity to condition darkness provided by the condition affinity below prevents one with devil sight and similar abilities, causing other problems
-        // so here we remove this immunity
-        if (!Main.Settings.AttackersWithDarkvisionHaveAdvantageOverDefendersWithout) return;
-        FeatureDefinitionCombatAffinitys.CombatAffinityVeil.myAttackAdvantage = AdvantageType.None;
-        FeatureDefinitionConditionAffinitys.ConditionAffinityInvocationDevilsSight.conditionAffinityType = ConditionAffinityType.None;
     }
 
     private static void FixColorTables()

--- a/SolastaUnfinishedBusiness/Models/FixesContext.cs
+++ b/SolastaUnfinishedBusiness/Models/FixesContext.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using SolastaUnfinishedBusiness.Api.GameExtensions;
@@ -38,6 +38,7 @@ internal static class FixesContext
         FixStunningStrikeForAnyMonkWeapon();
         FixTwinnedMetamagic();
         FixWildshapeGroupAttacks();
+        FixDarknessImplementation();
 
         // avoid folks tweaking max party size directly on settings as we don't need to stress cloud servers
         Main.Settings.OverridePartySize = Math.Min(Main.Settings.OverridePartySize, ToolsContext.MaxPartySize);
@@ -57,6 +58,16 @@ internal static class FixesContext
 
         ActionAffinityUncannyDodge.SetCustomSubFeatures(new ValidatorsDefinitionApplication(
             IsActionAffinityUncannyDodgeValid(RoguishDuelist.ConditionReflexiveParry)));
+    }
+
+    private static void FixDarknessImplementation()
+    {
+        //BUGFIX: Now that we have better handled sight and advantage elsewhere, darkness should no more give other source of disadvantage on attack
+        // and the immunity to condition darkness provided by the condition affinity below prevents one with devil sight and similar abilities, causing other problems
+        // so here we remove this immunity
+        if (!Main.Settings.AttackersWithDarkvisionHaveAdvantageOverDefendersWithout) return;
+        FeatureDefinitionCombatAffinitys.CombatAffinityVeil.myAttackAdvantage = AdvantageType.None;
+        FeatureDefinitionConditionAffinitys.ConditionAffinityInvocationDevilsSight.conditionAffinityType = ConditionAffinityType.None;
     }
 
     private static void FixColorTables()

--- a/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
@@ -365,6 +365,23 @@ internal static class SrdAndHouseRulesContext
         }
     }
 
+    internal static void FixDarknessSpell()
+    {
+        //BUGFIX: Now that we have better handled sight and advantage elsewhere, darkness should no more give other source of disadvantage on attack
+        // and the immunity to condition darkness provided by the condition affinity below prevents one with devil sight and similar abilities, causing other problems
+        // so here we remove this immunity
+        if (Main.Settings.AttackersWithDarkvisionHaveAdvantageOverDefendersWithout)
+        {
+            FeatureDefinitionCombatAffinitys.CombatAffinityVeil.myAttackAdvantage = AdvantageType.None;
+            FeatureDefinitionConditionAffinitys.ConditionAffinityInvocationDevilsSight.conditionAffinityType = ConditionAffinityType.None;
+        }
+        else
+        {
+            FeatureDefinitionCombatAffinitys.CombatAffinityVeil.myAttackAdvantage = AdvantageType.Disadvantage;
+            FeatureDefinitionConditionAffinitys.ConditionAffinityInvocationDevilsSight.conditionAffinityType = ConditionAffinityType.Immunity;
+        }
+    }
+
     internal static void SwitchEldritchBlastRange()
     {
         EldritchBlast.effectDescription.rangeParameter = Main.Settings.FixEldritchBlastRange ? 24 : 16;


### PR DESCRIPTION
Now that we have better handled sight and advantage elsewhere (if switched on), darkness should no more give other source of disadvantage on attack. Besides, the immunity to condition darkness provided by the condition affinity prevents one with devil sight and similar abilities from inflicting condition darkness, causing other problems (like attackers with darkvision ignore your obscurity as if you are in normal unlit condition) so I removed this immunity.
