### PR TITLE
Eliminate allocations

### DIFF
--- a/SolastaUnfinishedBusiness/Patches/DeterministicRandomPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/DeterministicRandomPatcher.cs
@@ -19,30 +19,14 @@ public static class DeterministicRandomPatcher
 
     private static Random.State MyStateToRandomState(ulong myState)
     {
-        var ms = new MyState { State = myState };
-
-        Object o = ms;
-
-        return CopyStruct<Random.State>(ref o);
+        Span<MyState> s = new MyState[1] { new MyState { State = myState } };
+        return MemoryMarshal.Cast<MyState, Random.State>(s)[0];
     }
 
     private static ulong RandomStateToMyState(Random.State state)
     {
-        Object o = state;
-
-        var ms = CopyStruct<MyState>(ref o);
-
-        return ms.State;
-    }
-
-    private static T CopyStruct<T>(ref object s1)
-    {
-        var handle = GCHandle.Alloc(s1, GCHandleType.Pinned);
-        var typedStruct = (T)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(T));
-
-        handle.Free();
-
-        return typedStruct;
+        Span<Random.State> s = new Random.State[1] { state };
+        return MemoryMarshal.Cast<Random.State, MyState>(s)[0].State;
     }
 
     private static float Next(double minValue, double maxValue)

--- a/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
+++ b/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
@@ -18,14 +18,14 @@
   </PropertyGroup>
 
   <Target Name="CheckEnvironmentVars">
-    <Error Text="Please set the SolastaInstallDir environment variable." Condition="'$(SolastaInstallDir)' == ''" ContinueOnError="false"/>
+    <Error Text="Please set the SolastaInstallDir environment variable." Condition="'$(SolastaInstallDir)' == ''" ContinueOnError="false" />
   </Target>
 
   <Target Name="Publicise" AfterTargets="Clean">
     <ItemGroup>
-      <PubliciseInputAssemblies Include="$(SolastaInstallDir)/Solasta_Data/Managed/Assembly-CSharp.dll"/>
+      <PubliciseInputAssemblies Include="$(SolastaInstallDir)/Solasta_Data/Managed/Assembly-CSharp.dll" />
     </ItemGroup>
-    <Publicise AssemblyPath="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/"/>
+    <Publicise AssemblyPath="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/" />
   </Target>
 
   <ItemGroup>
@@ -57,9 +57,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="System.IO.Compression"/>
-    <Reference Include="System.Web"/>
-    <Reference Include="System.Web.Extensions"/>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="0Harmony">
       <HintPath>$(SolastaInstallDir)/Solasta_Data/Managed/UnityModManager/0Harmony.dll</HintPath>
       <Private>false</Private>
@@ -224,15 +225,15 @@
   </ItemGroup>
 
   <Target Name="ZipTranslations" BeforeTargets="Compile"> <!-- Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU' Or '$(Configuration)|$(Platform)' == 'Debug Install|AnyCPU'"> -->
-    <ZipDirectory Overwrite="true" SourceDirectory="$(ProjectDir)/Translations/" DestinationFile="$(ProjectDir)/Resources/Translations.zip"/>
+    <ZipDirectory Overwrite="true" SourceDirectory="$(ProjectDir)/Translations/" DestinationFile="$(ProjectDir)/Resources/Translations.zip" />
   </Target>
 
   <ItemGroup Condition="('$(Configuration)|$(Platform)' == 'Release|AnyCPU' Or '$(Configuration)|$(Platform)' == 'Release Install|AnyCPU')">
-    <Compile Remove="Api/DatabaseHelper.cs"/>
+    <Compile Remove="Api/DatabaseHelper.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="('$(Configuration)|$(Platform)' == 'Debug|AnyCPU' Or '$(Configuration)|$(Platform)' == 'Debug Install|AnyCPU')">
-    <Compile Remove="Api/DatabaseHelper-RELEASE.cs"/>
+    <Compile Remove="Api/DatabaseHelper-RELEASE.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi Zappa good to see you're keeping up the good work.  
We can't have you using GCHandle.Alloc, so last century.  Try this alloc free approach.  
Requires System.Memory.
I played with this enabled and nothing bad happened, but that's as far as my testing went.