### PR TITLE
Fixed bug where Chinese, Japanese and Korean did not wrap the line correctly

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
@@ -140,6 +140,13 @@ internal static class GameUiDisplay
                 Main.Settings.DontFollowMargin = intValue;
             }
         }
+        
+        UI.Label();
+        toggle = Main.Settings.FixCJKWrappingError;
+        if (UI.Toggle(Gui.Localize("ModUi/&FixCJKWrappingError"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.FixCJKWrappingError = toggle;
+        }
 
         UI.Label();
 

--- a/SolastaUnfinishedBusiness/Patches/TextBreakerPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/TextBreakerPatcher.cs
@@ -1,0 +1,361 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+using System.Text.RegularExpressions;
+using HarmonyLib;
+using JetBrains.Annotations;
+using Mono.Cecil.Cil;
+using UnityEngine;
+using OpCodes = System.Reflection.Emit.OpCodes;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+/// <summary>
+/// Fixed incorrect line breaks in CJK language
+/// </summary>
+[UsedImplicitly]
+public static class TextBreakerPatcher
+{
+    public static Regex RegexHasCJK = new Regex(@"\p{IsCJKUnifiedIdeographs}", RegexOptions.Compiled);
+    
+    public static bool IsCJKChar(char c)
+    {
+        return c >= 0x4E00 && c <= 0x9FA5;
+    }
+    
+    public static bool HasCJKChar(string s)
+    {
+        return s.Length > 0 && RegexHasCJK.IsMatch(s);
+    }
+    
+    public static bool HasCJKCharQuick(string s)
+    {
+        return s.Length > 0 && IsCJKChar(s[0]);
+    }
+
+    [UsedImplicitly]
+    [HarmonyPatch(typeof(TextBreaker), nameof(TextBreaker.BreakdownFragments))]
+    public static class BreakdownFragments_Patch
+    {
+        [UsedImplicitly]
+        [HarmonyPrefix]
+        public static bool Prefix(TextBreaker __instance, string textLine,
+            TextFragmentStyleDescription style, bool handleSprites = false)
+        {
+            if (!Main.Settings.FixCJKWrappingError)
+            {
+                return true;
+            }
+            
+            BreakdownFragments_Fixed(__instance, textLine, style, handleSprites);
+            return false;
+        }
+
+        // Copy from dnSpy
+        public static void BreakdownFragments_Fixed(TextBreaker textBreaker, string textLine,
+            TextFragmentStyleDescription style, bool handleSprites = false)
+        {
+            textBreaker.fragments.Clear();
+            if (handleSprites)
+            {
+                textLine = textLine.Replace("sprite index", "sprite_index");
+            }
+
+            // Changed here
+            var fragments = SplitText(textLine);
+            // End of change
+
+            foreach (string text in fragments)
+            {
+                TextBreaker.FragmentInfo fragmentInfo = new TextBreaker.FragmentInfo(
+                    handleSprites ? text.Replace("sprite_index", "sprite index") : text, style, null, null);
+                textBreaker.fragments.Add(fragmentInfo);
+            }
+
+            for (int j = 0; j < textBreaker.fragments.Count; j++)
+            {
+                TextBreaker.FragmentInfo fragmentInfo2 = textBreaker.fragments[j];
+                int num = 0;
+                while (fragmentInfo2.contentValue.StartsWith("\n") &&
+                       fragmentInfo2.contentValue.Length > Environment.NewLine.Length && num++ < 1000)
+                {
+                    fragmentInfo2.contentValue =
+                        fragmentInfo2.contentValue.Substring(fragmentInfo2.contentValue.IndexOf('\n') + 1);
+                    fragmentInfo2.newLine = true;
+                }
+
+                num = 0;
+                while (fragmentInfo2.contentValue.EndsWith("\n") && num++ < 1000)
+                {
+                    fragmentInfo2.contentValue =
+                        fragmentInfo2.contentValue.Substring(fragmentInfo2.contentValue.LastIndexOf('\n'));
+                    if (j < textBreaker.fragments.Count - 1)
+                    {
+                        TextBreaker.FragmentInfo fragmentInfo3 = textBreaker.fragments[j + 1];
+                        fragmentInfo3.newLine = true;
+                        textBreaker.fragments[j + 1] = fragmentInfo3;
+                    }
+                }
+
+                int num2 = fragmentInfo2.contentValue.IndexOf('\n');
+                if (num2 > 0)
+                {
+                    TextBreaker.FragmentInfo fragmentInfo4 =
+                        new TextBreaker.FragmentInfo(fragmentInfo2.contentValue.Substring(num2 + 1),
+                            fragmentInfo2.style, null, null);
+                    fragmentInfo4.newLine = true;
+                    if (j < textBreaker.fragments.Count - 1)
+                    {
+                        textBreaker.fragments.Insert(j + 1, fragmentInfo4);
+                    }
+                    else
+                    {
+                        textBreaker.fragments.Add(fragmentInfo4);
+                    }
+
+                    fragmentInfo2.contentValue = fragmentInfo2.contentValue.Substring(0, num2);
+                }
+
+                textBreaker.fragments[j] = fragmentInfo2;
+            }
+        }
+
+        public static List<string> SplitText(string textLine)
+        {
+            var texts = textLine.Split(new char[] { ' ' });
+            var fragments = new List<string>();
+            var sb = new StringBuilder();
+
+            foreach (var s in texts)
+            {
+                if (HasCJKChar(s))
+                {
+                    foreach (var c in s)
+                    {
+                        if (IsCJKChar(c))
+                        {
+                            fragments.Add(sb.ToString());
+                            sb.Clear();
+                            sb.Append(c);
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+                    }
+
+                    if (sb.Length > 0)
+                    {
+                        fragments.Add(sb.ToString());
+                        sb.Clear();
+                    }
+                }
+                else
+                {
+                    fragments.Add(s);
+                }
+            }
+
+            return fragments;
+        }
+    }
+
+    [UsedImplicitly]
+    [HarmonyPatch(typeof(TextBreaker), nameof(TextBreaker.DispatchFragments))]
+    public static class DispatchFragments_Patch
+    {
+        [HarmonyPrefix]
+        public static bool Prefix(TextBreaker __instance, float areaWidth, float indentWidth, float lineHeight,
+            float paragraphSpacing, float wordSpacing, bool indent, float currentY, ref float __result)
+        {
+            if (!Main.Settings.FixCJKWrappingError)
+            {
+                return true;
+            }
+            
+            __result = DispatchFragments_Fixed(__instance, areaWidth, indentWidth, lineHeight, paragraphSpacing,
+                wordSpacing,
+                indent, currentY);
+            return false;
+        }
+
+
+        // Copy from dnSpy
+        public static float DispatchFragments_Fixed(TextBreaker textBreaker, float areaWidth, float indentWidth,
+            float lineHeight, float paragraphSpacing, float wordSpacing, bool indent, float currentY)
+        {
+            float num = currentY;
+            float num2 = (indent ? indentWidth : 0f);
+            for (int i = 0; i < textBreaker.fragments.Count; i++)
+            {
+                TextBreaker.FragmentInfo fragmentInfo = textBreaker.fragments[i];
+                if (fragmentInfo.newLine)
+                {
+                    num2 = 0f;
+                    currentY += paragraphSpacing + lineHeight;
+                }
+
+                if (num2 + fragmentInfo.width > areaWidth)
+                {
+                    fragmentInfo.x = 0f;
+                    num2 = fragmentInfo.width;
+                    currentY += lineHeight;
+                }
+                else
+                {
+                    fragmentInfo.x = num2;
+                    num2 += fragmentInfo.width;
+                }
+
+                fragmentInfo.y = -currentY;
+                if (i < textBreaker.fragments.Count - 1 &&
+                    textBreaker.fragments[i + 1].contentValue.IndexOf(',') != 0 &&
+                    fragmentInfo.contentValue.IndexOf('+') != fragmentInfo.contentValue.Length - 1)
+                {
+                    // Changed here
+                    if (!HasCJKCharQuick(textBreaker.fragments[i].contentValue))
+                        num2 += wordSpacing;
+                    // End of change
+
+                    if (num2 > areaWidth)
+                    {
+                        num2 = 0f;
+                        currentY += lineHeight;
+                    }
+                }
+
+                textBreaker.fragments[i] = fragmentInfo;
+            }
+
+            currentY += lineHeight;
+            return currentY - num;
+        }
+    }
+
+    [UsedImplicitly]
+    public static class GameDocumentTablePatcher
+    {
+        [HarmonyPatch(typeof(GameDocumentTable), ".ctor", MethodType.Constructor)]
+        [UsedImplicitly]
+        public static class Constructor_Patch
+        {
+            [HarmonyPatch(MethodType.Constructor)]
+            [HarmonyPatch(new Type[] {typeof(DocumentTableDefinition), typeof(DocumentDescription), typeof(ITextComputer)})]
+            [HarmonyTranspiler]
+            [UsedImplicitly]
+            [HarmonyDebug]
+            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator il)
+            {
+                if (!Main.Settings.FixCJKWrappingError)
+                {
+                    return instructions;
+                }
+                
+                var codes = instructions.ToList();
+
+                var startIndex = -1;
+                var endIndex = -1;
+                for (var index = 0; index < codes.Count; index++)
+                {
+                    var code = codes[index];
+                    // find num += wordSpacing;
+                    if(code.opcode == OpCodes.Ldloc_S && code.operand is LocalBuilder { LocalIndex: 14 } && index < codes.Count - 1)
+                    {
+                        var nextCode = codes[index + 1];
+                        if(nextCode.opcode == OpCodes.Ldloc_S && nextCode.operand is LocalBuilder { LocalIndex: 10 })
+                        {
+                            startIndex = index;
+                            endIndex = index + 4;
+                            break;
+                        }
+                    }
+                }
+
+                MakeTranspiler(codes, startIndex, endIndex, 15, il);
+
+                return codes;
+            }
+            
+            [HarmonyPatch(new Type[] {typeof(DocumentTableDefinition), typeof(string), typeof(string), typeof(ITextComputer)})]
+            [HarmonyTranspiler]
+            [UsedImplicitly]
+            [HarmonyDebug]
+            public static IEnumerable<CodeInstruction> Transpiler2(IEnumerable<CodeInstruction> instructions, ILGenerator il)
+            {
+                if (!Main.Settings.FixCJKWrappingError)
+                {
+                    return instructions;
+                }
+                
+                var codes = instructions.ToList();
+
+                var startIndex = -1;
+                var endIndex = -1;
+                for (var index = 0; index < codes.Count; index++)
+                {
+                    var code = codes[index];
+                    // find num += wordSpacing;
+                    if(code.opcode == OpCodes.Ldloc_S && code.operand is LocalBuilder { LocalIndex: 5 } && index < codes.Count - 1)
+                    {
+                        var nextCode = codes[index + 1];
+                        if(nextCode.opcode == OpCodes.Ldloc_3)
+                        {
+                            startIndex = index;
+                            endIndex = index + 4;
+                            break;
+                        }
+                    }
+                }
+
+                MakeTranspiler(codes, startIndex, endIndex, 6, il);
+
+                return codes;
+            }
+
+            private static void MakeTranspiler(List<CodeInstruction> codes, int startCodeIndex, int jumpToCodeIndex, int localIndex, ILGenerator il)
+            {
+                if (startCodeIndex == -1)
+                {
+                    Main.Error("Cannot find the start index of the patch : GameDocumentTablePatcher");
+                    return;
+                }
+
+                var endCode = codes[jumpToCodeIndex];
+                // find the local variable of i
+                var localBuilder = codes.First(x => x.opcode == OpCodes.Ldloc_S && x.operand is LocalBuilder builder 
+                    && builder.LocalIndex == localIndex).operand as LocalBuilder;
+                
+                var endLabel = il.DefineLabel();
+                endCode.labels.Add(endLabel);
+
+                // C# Code:
+                // if (!HasCJKCharQuick(this.textBreaker.Fragments[i].contentValue))
+                //      num5 += num4;
+                var newCodes = new List<CodeInstruction>()
+                {
+                    // this
+                    new CodeInstruction(OpCodes.Ldarg_0),
+                    // this.textBreaker
+                    new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(GameDocumentTable), "textBreaker")),
+                    // this.textBreaker.Fragments
+                    new CodeInstruction(OpCodes.Callvirt, AccessTools.Property(typeof(TextBreaker), "Fragments").GetGetMethod()),
+                    // i
+                    new CodeInstruction(OpCodes.Ldloc_S, localBuilder),
+                    // this.textBreaker.Fragments[i]
+                    new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(List<TextBreaker.FragmentInfo>), "get_Item")),
+                    // this.textBreaker.Fragments[i].contentValue
+                    new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(TextBreaker.FragmentInfo), "contentValue")),
+                    // HasCJKCharQuick(this.textBreaker.Fragments[i].contentValue)
+                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(TextBreakerPatcher), nameof(HasCJKCharQuick))),
+                    // if (!HasCJKCharQuick(this.textBreaker.Fragments[i].contentValue))
+                    new CodeInstruction(OpCodes.Brtrue_S, endLabel),
+                };
+
+                codes.InsertRange(startCodeIndex, newCodes);
+            }
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -272,6 +272,7 @@ public class Settings : UnityModManager.ModSettings
     // Campaigns and Locations
     public bool DontFollowCharacterInBattle { get; set; }
     public int DontFollowMargin { get; set; } = 5;
+    public bool FixCJKWrappingError { get; set; }
     public bool ShowChannelDivinityOnPortrait { get; set; }
     public bool EnableStatsOnHeroTooltip { get; set; }
     public bool EnableAdditionalBackstoryDisplay { get; set; }

--- a/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
+++ b/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
@@ -18,14 +18,14 @@
   </PropertyGroup>
 
   <Target Name="CheckEnvironmentVars">
-    <Error Text="Please set the SolastaInstallDir environment variable." Condition="'$(SolastaInstallDir)' == ''" ContinueOnError="false"/>
+    <Error Text="Please set the SolastaInstallDir environment variable." Condition="'$(SolastaInstallDir)' == ''" ContinueOnError="false" />
   </Target>
 
   <Target Name="Publicise" AfterTargets="Clean">
     <ItemGroup>
-      <PubliciseInputAssemblies Include="$(SolastaInstallDir)/Solasta_Data/Managed/Assembly-CSharp.dll"/>
+      <PubliciseInputAssemblies Include="$(SolastaInstallDir)/Solasta_Data/Managed/Assembly-CSharp.dll" />
     </ItemGroup>
-    <Publicise AssemblyPath="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/"/>
+    <Publicise AssemblyPath="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/" />
   </Target>
 
   <ItemGroup>
@@ -58,9 +58,9 @@
 
   <ItemGroup>
     <!-- <PackageReference Include="System.Memory" Version="4.5.5" /> -->
-    <Reference Include="System.IO.Compression"/>
-    <Reference Include="System.Web"/>
-    <Reference Include="System.Web.Extensions"/>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="0Harmony">
       <HintPath>$(SolastaInstallDir)/Solasta_Data/Managed/UnityModManager/0Harmony.dll</HintPath>
       <Private>false</Private>
@@ -225,15 +225,15 @@
   </ItemGroup>
 
   <Target Name="ZipTranslations" BeforeTargets="Compile"> <!-- Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU' Or '$(Configuration)|$(Platform)' == 'Debug Install|AnyCPU'"> -->
-    <ZipDirectory Overwrite="true" SourceDirectory="$(ProjectDir)/Translations/" DestinationFile="$(ProjectDir)/Resources/Translations.zip"/>
+    <ZipDirectory Overwrite="true" SourceDirectory="$(ProjectDir)/Translations/" DestinationFile="$(ProjectDir)/Resources/Translations.zip" />
   </Target>
 
   <ItemGroup Condition="('$(Configuration)|$(Platform)' == 'Release|AnyCPU' Or '$(Configuration)|$(Platform)' == 'Release Install|AnyCPU')">
-    <Compile Remove="Api/DatabaseHelper.cs"/>
+    <Compile Remove="Api/DatabaseHelper.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="('$(Configuration)|$(Platform)' == 'Debug|AnyCPU' Or '$(Configuration)|$(Platform)' == 'Debug Install|AnyCPU')">
-    <Compile Remove="Api/DatabaseHelper-RELEASE.cs"/>
+    <Compile Remove="Api/DatabaseHelper-RELEASE.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SolastaUnfinishedBusiness/Translations/de/Settings-de.txt
+++ b/SolastaUnfinishedBusiness/Translations/de/Settings-de.txt
@@ -125,6 +125,7 @@ ModUi/&FeatGroups=<color=#F0DAA0>Feature-Gruppen</color>
 ModUi/&FeatGroupsHelp=. Jede Gruppe ist eine Konsolidierung ähnlicher Leistungen <i><color=#F0DAA0>[d. h. Glaubensbekenntnisse, Kampfstile, Metamagie usw.]</color></i>\n. Leistungen in diesen Gruppen werden in der Kompetenzauswahlphase nicht mehr direkt sichtbar sein\n. Wenn die Gruppe ausgewählt ist, werden sie in einer Dropdown-Liste angezeigt, um den Spielbildschirm übersichtlicher zu gestalten
 ModUi/&Feats=<color=#F0DAA0>Talente</color>
 ModUi/&FightingStyles=<color=#F0DAA0>Kampfstile</color>
+ModUi/&FixCJKWrappingError=Behebung eines Umbruchfehlers im CJK-Text <b><i><color=#C04040E0>[Neustart erforderlich]</color></i></b>
 ModUi/&FixEldritchBlastRange=Ändern Sie die Reichweite von <color=#D89555>Eldritch Blast</color> auf 24 <i><color=#F0DAA0>[statt 16]</color></i>
 ModUi/&Formation=<color=#F0DAA0>Formation:</color>
 ModUi/&FormationError=<color=#C04040E0>Sie können Ihre Formation während eines Mehrspielerspiels nicht ändern...</color>

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -1,5 +1,6 @@
 ModUi/&AddAllToStore=Add all to store
 ModUi/&AddBleedingToLesserRestoration=Add the <color=#D89555>Bleeding</color> condition to the ones removed by <color=#D89555>Greater</color> and <color=#D89555>Lesser Restoration</color>
+ModUi/&FixCJKWrappingError=Fix a wrapping error in CJK text <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&AddCustomIconsToOfficialItems=Add custom icons to official game items <i><color=#F0DAA0>[ammunition, recipes, kits, etc.]</color></i> <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&AddHelpActionToAllRaces=Add the <color=#D89555>Help</color> action to all playable races <i><color=#F0DAA0>[you can aid a friendly creature in attacking a creature within 5 ft of you]</color></i>
 ModUi/&AddHumanoidFavoredEnemyToRanger=Add humanoid preferred enemy to <color=#D89555>Rangers</color>

--- a/SolastaUnfinishedBusiness/Translations/es/Settings-es.txt
+++ b/SolastaUnfinishedBusiness/Translations/es/Settings-es.txt
@@ -125,6 +125,7 @@ ModUi/&FeatGroups=<color=#F0DAA0>Grupos de características</color>
 ModUi/&FeatGroupsHelp=. Cada grupo es una consolidación de hazañas similares <i><color=#F0DAA0>[es decir, credos, estilos de lucha, metamagia, etc.]</color></i>\n. Las dotes en estos grupos ya no serán visibles directamente en la etapa de selección de competencia\n. El grupo, cuando se selecciona, los ofrece en una lista desplegable para despejar la pantalla del juego.
 ModUi/&Feats=<color=#F0DAA0>Dotes</color>
 ModUi/&FightingStyles=<color=#F0DAA0>Estilos de lucha</color>
+ModUi/&FixCJKWrappingError=Solucione un error de ajuste en el texto CJK <b><i><color=#C04040E0>[Requiere reiniciar]</color></i></b>
 ModUi/&FixEldritchBlastRange=Cambia el rango de <color=#D89555>Explosión sobrenatural</color> a 24 <i><color=#F0DAA0>[en lugar de 16]</color></i>
 ModUi/&Formation=<color=#F0DAA0>Formación:</color>
 ModUi/&FormationError=<color=#C04040E0>No puedes cambiar tu formación durante una partida multijugador...</color>

--- a/SolastaUnfinishedBusiness/Translations/fr/Settings-fr.txt
+++ b/SolastaUnfinishedBusiness/Translations/fr/Settings-fr.txt
@@ -125,6 +125,7 @@ ModUi/&FeatGroups=<color=#F0DAA0>Groupes de fonctions</color>
 ModUi/&FeatGroupsHelp=. Chaque groupe est une consolidation d'exploits similaires <i><color=#F0DAA0>[c'est-à-dire : croyances, styles de combat, métamagie, etc.]</color></i>\n. Les exploits de ces groupes ne seront plus directement visibles lors de l'étape de sélection des compétences\n. Le groupe, lorsqu'il est sélectionné, les propose sur une liste déroulante pour désencombrer l'écran de jeu
 ModUi/&Feats=<color=#F0DAA0>Exploits</color>
 ModUi/&FightingStyles=<color=#F0DAA0>Styles de combat</color>
+ModUi/&FixCJKWrappingError=Correction d'une erreur d'habillage dans le texte CJC <b><i><color=#C04040E0>[Nécessite un redémarrage]</color></i></b>
 ModUi/&FixEldritchBlastRange=Changez la plage <color=#D89555>Eldritch Blast</color> à 24 <i><color=#F0DAA0>[au lieu de 16]</color></i>
 ModUi/&Formation=<color=#F0DAA0>Formation :</color>
 ModUi/&FormationError=<color=#C04040E0>Vous ne pouvez pas changer de formation pendant une partie multijoueur...</color>

--- a/SolastaUnfinishedBusiness/Translations/it/Settings-it.txt
+++ b/SolastaUnfinishedBusiness/Translations/it/Settings-it.txt
@@ -125,6 +125,7 @@ ModUi/&FeatGroups=<color=#F0DAA0>Gruppi di talenti</color>
 ModUi/&FeatGroupsHelp=. Ogni gruppo è un consolidamento di talenti simili <i><color=#F0DAA0>[ad es.: credi, stili di combattimento, metamagia, ecc.]</color></i>\n. I talenti in questi gruppi non saranno più direttamente visibili nella fase di selezione delle competenze\n. Il gruppo, quando selezionato, li offre in un elenco a discesa per riordinare la schermata di gioco
 ModUi/&Feats=<color=#F0DAA0> Talenti</color>
 ModUi/&FightingStyles=<color=#F0DAA0>Stili di combattimento</color>
+ModUi/&FixCJKWrappingError=Correggi un errore di a capo nel testo CJK <b><i><color=#C04040E0>[Richiede il riavvio]</color></i></b>
 ModUi/&FixEldritchBlastRange=Cambia la portata di <color=#D89555>Eldritch Blast</color> a 24 <i><color=#F0DAA0>[invece di 16]</color></i>
 ModUi/&Formation=<color=#F0DAA0>Formazione:</color>
 ModUi/&FormationError=<color=#C04040E0>Non puoi cambiare la tua formazione durante una partita multiplayer...</color>

--- a/SolastaUnfinishedBusiness/Translations/ja/Settings-ja.txt
+++ b/SolastaUnfinishedBusiness/Translations/ja/Settings-ja.txt
@@ -125,6 +125,7 @@ ModUi/&FeatGroups=<color=#F0DAA0>特技グループ</color>
 ModUi/&FeatGroupsHelp=。各グループは、同様の特技<i><color=#F0DAA0>[例: 信条、戦闘スタイル、メタマジックなど]</color></i>\n を統合したものです。これらのグループの特技は、熟練度選択ステージで直接表示されなくなります\n。グループを選択すると、ゲーム画面を整理するためにドロップダウン リストにグループが表示されます。
 ModUi/&Feats=<color=#F0DAA0>特技</color>
 ModUi/&FightingStyles=<color=#F0DAA0>戦闘スタイル</color>
+ModUi/&FixCJKWrappingError=CJK テキストの折り返しエラーを修正<b><i><color=#C04040E0>[再起動が必要]</color></i></b>
 ModUi/&FixEldritchBlastRange=<color=#D89555>エルドリッチブラスト</color>の範囲を<i><color=#F0DAA0>[16ではなく]</color></i> 24に変更します。
 ModUi/&Formation=<color=#F0DAA0>フォーメーション:</color>
 ModUi/&FormationError=<color=#C04040E0>マルチプレイヤー ゲーム中にフォーメーションを変更することはできません...</color>

--- a/SolastaUnfinishedBusiness/Translations/ko/Settings-ko.txt
+++ b/SolastaUnfinishedBusiness/Translations/ko/Settings-ko.txt
@@ -125,6 +125,7 @@ ModUi/&FeatGroups=<color=#F0DAA0>피트 그룹</color>
 ModUi/&FeatGroupsHelp=. 각 그룹은 유사한 업적 <i><color=#F0DAA0>[즉: 신조, 격투 스타일, 메타마법 등]</color></i>\n의 통합입니다. 이 그룹의 위업은 숙련도 선택 단계에서 더 이상 직접 볼 수 없습니다\n. 그룹을 선택하면 게임 화면을 깔끔하게 정리할 수 있도록 드롭다운 목록에 제공됩니다.
 ModUi/&Feats=<color=#F0DAA0>재주</color>
 ModUi/&FightingStyles=<color=#F0DAA0>전투 스타일</color>
+ModUi/&FixCJKWrappingError=CJK 텍스트의 래핑 오류 수정 <b><i><color=#C04040E0>[재시작 필요]</color></i></b>
 ModUi/&FixEldritchBlastRange=<color=#D89555>엘드리치 폭발</color> 범위를 24 <i><color=#F0DAA0>[16 대신]</color></i>로 변경
 ModUi/&Formation=<color=#F0DAA0>형성:</color>
 ModUi/&FormationError=<color=#C04040E0>멀티플레이어 게임 중에는 포메이션을 변경할 수 없습니다...</color>

--- a/SolastaUnfinishedBusiness/Translations/pt-BR/Settings-pt-BR.txt
+++ b/SolastaUnfinishedBusiness/Translations/pt-BR/Settings-pt-BR.txt
@@ -125,6 +125,7 @@ ModUi/&FeatGroups=<color=#F0DAA0>Grupos de talentos</color>
 ModUi/&FeatGroupsHelp=. Cada grupo é uma consolidação de talentos semelhantes <i><color=#F0DAA0>[ou seja: credos, estilos de luta, metamagia, etc]</color></i>\n. Os talentos desses grupos não serão mais visíveis diretamente no estágio de seleção de proficiência\n. O grupo, quando selecionado, os oferece em uma lista suspensa para desorganizar a tela do jogo
 ModUi/&Feats=<color=#F0DAA0>Feats</color>
 ModUi/&FightingStyles=<color=#F0DAA0>Estilos de luta</color>
+ModUi/&FixCJKWrappingError=Correção de um erro de agrupamento no texto CJK <b><i><color=#C04040E0>[Requer reinicialização]</color></i></b>
 ModUi/&FixEldritchBlastRange=Altere o intervalo de <color=#D89555>Eldritch Blast</color> para 24 <i><color=#F0DAA0>[em vez de 16]</color></i>
 ModUi/&Formation=<color=#F0DAA0>Formação:</color>
 ModUi/&FormationError=<color=#C04040E0>Você não pode mudar sua formação durante um jogo multijogador...</color>

--- a/SolastaUnfinishedBusiness/Translations/zh-CN/Settings-zh-CN.txt
+++ b/SolastaUnfinishedBusiness/Translations/zh-CN/Settings-zh-CN.txt
@@ -125,6 +125,7 @@ ModUi/&FeatGroups=<color=#F0DAA0>专长组</color>
 ModUi/&FeatGroupsHelp=.每个组都是相似专长的综合<i><color=#F0DAA0>[即：信条、战斗风格、超魔等]</color></i>\n。这些组中的专长将不再直接显示在熟练程度选择阶段\n。该组在被选中后会在下拉列表中提供它们以供选择。
 ModUi/&Feats=<color=#F0DAA0>专长</color>
 ModUi/&FightingStyles=<color=#F0DAA0>战斗风格</color>
+ModUi/&FixCJKWrappingError=修复中日韩文本中的换行错误 <b><i><color=#C04040E0>[需要重启]</color></i></b>
 ModUi/&FixEldritchBlastRange=将<color=#D89555>魔能爆</color>范围更改为24<i><color=#F0DAA0>[而不是16]</color></i>
 ModUi/&Formation=<color=#F0DAA0>队形：</color>
 ModUi/&FormationError=<color=#C04040E0>你不能在多人游戏中改变你的阵型...</color>


### PR DESCRIPTION
# Why fix this
https://github.com/SolastaMods/SolastaUnfinishedBusiness/issues/3394
Solasta's way of wrapping text is to use Spaces to break up words, but there are no Spaces between characters in CJK(Chinese, Japanese and Korean), so there is a wrapping error.

# Principle of repair
Changed how to Split CJK text, and eliminates the spacing between CJK character.

# How to enable
This fix is switchable because I am concerned about the possible impact on other languages.(Although according to my tests there should be no other effect)
It's in Interface > Game UI > Campaigns and locations. I don't know where to put it right now.