### PR TITLE
Poisoner Feat rework

### DIFF
--- a/SolastaUnfinishedBusiness/CustomBehaviors/ValidateDeviceFunctionUse.cs
+++ b/SolastaUnfinishedBusiness/CustomBehaviors/ValidateDeviceFunctionUse.cs
@@ -1,0 +1,12 @@
+﻿namespace SolastaUnfinishedBusiness.CustomBehaviors;
+
+/**
+ * Used to determine whether device function should be usable
+ * So far implemented only for FeatureDefinitionActionAffinity and FeatureDefinitionAdditionalAction authorizing Bonus Action device use
+ * Used for Poisoner feat
+ * Can be extended to affect any specific device if needed
+ */
+public delegate bool ValidateDeviceFunctionUse(
+    RulesetCharacter user,  
+    RulesetItemDevice device, 
+    RulesetDeviceFunction deviceFunction);

--- a/SolastaUnfinishedBusiness/Feats/ClassFeats.cs
+++ b/SolastaUnfinishedBusiness/Feats/ClassFeats.cs
@@ -486,7 +486,13 @@ internal static class ClassFeats
             .Create(Name)
             .SetGuiPresentation(Category.Feat)
             .SetFeatures(
-                FeatureDefinitionActionAffinitys.ActionAffinityThiefFastHands,
+                FeatureDefinitionActionAffinityBuilder
+                    .Create($"ActionAffinity{Name}")
+                    .SetGuiPresentation(Category.Feature)
+                    .SetCustomSubFeatures(new ValidateDeviceFunctionUse((_, device, _) =>
+                        device.UsableDeviceDescription.UsableDeviceTags.Contains("Poison")))
+                    .SetAuthorizedActions(ActionDefinitions.Id.UseItemBonus)
+                    .AddToDB(),
                 FeatureDefinitionCraftingAffinityBuilder
                     .Create($"CraftingAffinity{Name}")
                     .SetGuiPresentationNoContent(true)
@@ -500,47 +506,6 @@ internal static class ClassFeats
                     .AddToDB())
             .SetValidators(ValidatorsFeat.IsRangerOrRogueLevel4)
             .AddToDB();
-    }
-
-    internal static void TweakUseItemBonusActionId(
-        IControllableCharacter __instance,
-        ref ActionDefinitions.ActionStatus __result,
-        ActionDefinitions.Id actionId)
-    {
-        // no changes if not an available use item bonus action in battle
-        if (Gui.Battle == null ||
-            actionId != ActionDefinitions.Id.UseItemBonus ||
-            __result != ActionDefinitions.ActionStatus.Available)
-        {
-            return;
-        }
-
-        // no changes if character is Roguish Thief or Grenadier
-        var hero = __instance.RulesetCharacter as RulesetCharacterHero ??
-                   __instance.RulesetCharacter.OriginalFormCharacter as RulesetCharacterHero;
-
-        if (hero == null ||
-            (hero.ClassesAndSubclasses.TryGetValue(Rogue, out var rogueSub) &&
-             rogueSub.Name == "RoguishThief") ||
-            (hero.ClassesAndSubclasses.TryGetValue(InventorClass.Class, out var inventorSub) &&
-             inventorSub.Name == "InnovationAlchemy"))
-        {
-            return;
-        }
-
-        // no changes if device is poison
-        __instance.RulesetCharacter.RefreshUsableDeviceFunctions();
-
-        if (__instance.RulesetCharacter.EnumerateAvailableDevices(false)
-            .Where(enumerateAvailableDevice =>
-                __instance.RulesetCharacter.UsableDeviceFunctionsByDevice.ContainsKey(enumerateAvailableDevice))
-            .All(enumerateAvailableDevice =>
-                enumerateAvailableDevice.UsableDeviceDescription.UsableDeviceTags.Contains("Poison")))
-        {
-            return;
-        }
-
-        __result = ActionDefinitions.ActionStatus.CannotPerform;
     }
 
     #endregion

--- a/SolastaUnfinishedBusiness/Patches/GameLocationCharacterPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/GameLocationCharacterPatcher.cs
@@ -10,7 +10,6 @@ using SolastaUnfinishedBusiness.Api.Helpers;
 using SolastaUnfinishedBusiness.CustomBehaviors;
 using SolastaUnfinishedBusiness.CustomInterfaces;
 using SolastaUnfinishedBusiness.CustomUI;
-using SolastaUnfinishedBusiness.Feats;
 using SolastaUnfinishedBusiness.Models;
 
 namespace SolastaUnfinishedBusiness.Patches;
@@ -189,9 +188,6 @@ public static class GameLocationCharacterPatcher
             //PATCH: support for custom invocation action ids
             CustomActionIdContext.ProcessCustomActionIds(__instance, ref __result, actionId, scope, actionTypeStatus,
                 ignoreMovePoints);
-
-            //PATCH: support `Poisoner` feat to only allow poisons to be used on use item bonus
-            ClassFeats.TweakUseItemBonusActionId(__instance, ref __result, actionId);
         }
     }
 

--- a/SolastaUnfinishedBusiness/Patches/UsableDeviceFunctionBoxPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/UsableDeviceFunctionBoxPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using HarmonyLib;
 using JetBrains.Annotations;
 using SolastaUnfinishedBusiness.Api.GameExtensions;
@@ -17,6 +18,15 @@ public static class UsableDeviceFunctionBoxPatcher
         [UsedImplicitly]
         public static void Postfix(
             UsableDeviceFunctionBox __instance,
+            RulesetItemDevice usableDevice,
+            RulesetDeviceFunction usableDeviceFunction)
+        {
+            UpdateOverchargeForPowerDevice(__instance, usableDevice, usableDeviceFunction);
+            UpdateUsabilityForPoisoner(__instance, usableDevice, usableDeviceFunction);
+        }
+
+        private static void UpdateOverchargeForPowerDevice(
+            UsableDeviceFunctionBox box,
             RulesetItemDevice usableDevice,
             RulesetDeviceFunction usableDeviceFunction)
         {
@@ -60,7 +70,89 @@ public static class UsableDeviceFunctionBoxPatcher
                 return;
             }
 
-            __instance.overchargeButton.gameObject.SetActive(true);
+            box.overchargeButton.gameObject.SetActive(true);
+        }
+
+        private static void UpdateUsabilityForPoisoner(
+            UsableDeviceFunctionBox box,
+            RulesetItemDevice usableDevice,
+            RulesetDeviceFunction rulesetDeviceFunction)
+        {
+            /*
+             GetComponentInParent for some reason returns one layer deeper than needed - have TA added extra component by mistake?
+             DeviceSelectionPanel component is present in
+             `/Application/GUI/BackgroundCanvas/ForegroundCanvas/DeviceSelectionPanel`
+             and its child
+             `/Application/GUI/BackgroundCanvas/ForegroundCanvas/DeviceSelectionPanel/DeviceLinesTable`
+             this makes GetComponentInParent<DeviceSelectionPanel>() called on UsableDeviceFunctionBox 
+             return DeviceLinesTable's DeviceSelectionPanel component (which doesn't seem to be setup at all)
+             instead of properly setup component of DeviceSelectionPanel object.
+             This forces us to use chaining parent getters.
+            */
+            var panel = box.transform.parent.parent.parent.parent.GetComponent<DeviceSelectionPanel>();
+            var actionType = panel.ActionType;
+            if (actionType != ActionDefinitions.ActionType.Bonus)
+            {
+                return;
+            }
+
+            var user = box.GuiCharacter.RulesetCharacter;
+            
+            if (user.GetSubFeaturesByType<IActionPerformanceProvider>()
+                .Any(f => ValidPerformanceProvider(f, user, usableDevice, rulesetDeviceFunction)))
+            {
+                return;
+            }
+            
+            if (user.GetSubFeaturesByType<IAdditionalActionsProvider>()
+                .Any(f => ValidAdditinalActionProvider(f, user, usableDevice, rulesetDeviceFunction)))
+            {
+                return;
+            }
+
+            box.button.interactable = false;
+            box.canvasGroup.interactable = false;
+            box.canvasGroup.alpha = 0.1f;
+        }
+
+        private static bool ValidPerformanceProvider(
+            IActionPerformanceProvider provider,
+            RulesetCharacter user,
+            RulesetItemDevice device,
+            RulesetDeviceFunction deviceFunction)
+        {
+            if (!provider.AuthorizedActions.Contains(ActionDefinitions.Id.UseItemBonus))
+            {
+                return false;
+            }
+
+            if (provider is not FeatureDefinition feature)
+            {
+                return false;
+            }
+
+            var validator = feature.GetFirstSubFeatureOfType<ValidateDeviceFunctionUse>();
+            return validator == null || validator(user, device, deviceFunction);
+        }
+        
+        private static bool ValidAdditinalActionProvider(
+            IAdditionalActionsProvider provider,
+            RulesetCharacter user,
+            RulesetItemDevice device,
+            RulesetDeviceFunction deviceFunction)
+        {
+            if (!provider.AuthorizedActions.Contains(ActionDefinitions.Id.UseItemBonus))
+            {
+                return false;
+            }
+
+            if (provider is not FeatureDefinition feature)
+            {
+                return false;
+            }
+
+            var validator = feature.GetFirstSubFeatureOfType<ValidateDeviceFunctionUse>();
+            return validator == null || validator(user, device, deviceFunction);
         }
     }
 }


### PR DESCRIPTION
Reworked how Poisoner feat adds bonus action to use poisons : 
 - WAS: adds `Cunning Action: Fast Hands` action from Thief and then disables availability of UseItemBonus action if character is not Thief or Grenadier and has non-poison items to use.
 - NEW: always authorize `UseItemBonus` action, but disable devices which are not poisons if Use Device panel is opened for Bonus Action use.

This new approach fixes issue that didn't allow BA poison use if you had some other usable device equipped besides poison (for example Crown) and also reduces number of clicks. This solution also adds `ValidateDeviceFunctionUse` that opens other possibilities to use BA for item interaction like:
 - making new wizard feat that allows scroll usage for BA
 - making existing Healer feat allow BA potion use, but only on _others_, not on _self_