### PR TITLE
Added check of spellist to grant cha based modifier.

### DIFF
--- a/SolastaUnfinishedBusiness/Feats/ClassFeats.cs
+++ b/SolastaUnfinishedBusiness/Feats/ClassFeats.cs
@@ -885,7 +885,8 @@ internal static class ClassFeats
             string attribute;
 
             if (_spellListDefinition[0] == SpellListDefinitions.SpellListBard ||
-                _spellListDefinition[0] == SpellListDefinitions.SpellListSorcerer)
+                _spellListDefinition[0] == SpellListDefinitions.SpellListSorcerer||
+                _spellListDefinition[0] == SpellListDefinitions.SpellListWarlock)
 
             {
                 attribute = AttributeDefinitions.Charisma;


### PR DESCRIPTION
Before this fix, the potent spellcaster feat for warlock grants no bonus.
P.S.>This does stack with agonizing blast, considering there are not many ways to boost its damage, do I take this as intended?(Because if you want to boost other cantrips damage you just choose potent spellcaster bard)