### PR TITLE
Fix damage reduction

### DIFF
--- a/SolastaUnfinishedBusiness/Builders/Features/FeatureDefinitionReduceDamageBuilder.cs
+++ b/SolastaUnfinishedBusiness/Builders/Features/FeatureDefinitionReduceDamageBuilder.cs
@@ -28,11 +28,12 @@ internal class FeatureDefinitionReduceDamageBuilder
 
     [NotNull]
     internal FeatureDefinitionReduceDamageBuilder SetConsumeSpellSlotsReducedDamage(
-        CharacterClassDefinition spellCastingClass, int reducedDamage)
+        CharacterClassDefinition spellCastingClass, int reducedDamage, params string[] damageTypes)
     {
         Definition.SpellCastingClass = spellCastingClass;
         Definition.TriggerCondition = RuleDefinitions.AdditionalDamageTriggerCondition.SpendSpellSlot;
         Definition.ReducedDamage = reducedDamage;
+        Definition.DamageTypes.SetRange(damageTypes);
         return this;
     }
 

--- a/SolastaUnfinishedBusiness/CustomDefinitions/FeatureDefinitionReduceDamage.cs
+++ b/SolastaUnfinishedBusiness/CustomDefinitions/FeatureDefinitionReduceDamage.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using SolastaUnfinishedBusiness.Api.GameExtensions;
 
 namespace SolastaUnfinishedBusiness.CustomDefinitions;
 
@@ -9,4 +11,49 @@ internal sealed class FeatureDefinitionReduceDamage : FeatureDefinition
     public List<string> DamageTypes { get; set; }
     public string NotificationTag { get; set; }
     public CharacterClassDefinition SpellCastingClass { get; set; }
+
+    public static int DamageReduction(
+        RulesetImplementationDefinitions.ApplyFormsParams formsParams,
+        int damage,
+        string damageType)
+    {
+        var defender = formsParams.targetCharacter;
+        var reduction = 0;
+
+        foreach (var feature in defender.GetFeaturesByType<FeatureDefinitionReduceDamage>())
+        {
+            if (feature.DamageTypes != null 
+                && !feature.DamageTypes.Empty() 
+                && !feature.DamageTypes.Contains(damageType))
+            {
+                continue;
+            }
+
+            var prefix = $"{feature.Name}:{defender.Guid}:";
+            var k = formsParams.sourceTags.FindIndex(x => x.StartsWith(prefix));
+            if (k < 0) { continue; }
+
+            var tag = formsParams.sourceTags[k];
+            formsParams.sourceTags.RemoveAt(k);
+            try
+            {
+                var tmp = int.Parse(tag.Split(':')[2]);
+                if (reduction + tmp > damage)
+                {
+                    tmp = reduction + tmp - damage;
+                    formsParams.sourceTags.Add(prefix + tmp);
+                    reduction = damage;
+                    break;
+                }
+
+                reduction += tmp;
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+        
+        return reduction;
+    }
 }

--- a/SolastaUnfinishedBusiness/Patches/GameConsolePatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/GameConsolePatcher.cs
@@ -6,6 +6,7 @@ using System.Reflection.Emit;
 using HarmonyLib;
 using JetBrains.Annotations;
 using SolastaUnfinishedBusiness.Api.Helpers;
+using SolastaUnfinishedBusiness.CustomDefinitions;
 
 namespace SolastaUnfinishedBusiness.Patches;
 
@@ -47,6 +48,41 @@ public static class GameConsolePatcher
             }
 
             console.AddEntry(entry, insertionIndex);
+        }
+    }
+    
+    [HarmonyPatch(typeof(GameConsole), nameof(GameConsole.DamageReduced))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class DamageReduced_Patch
+    {
+        [UsedImplicitly]
+        public static bool Prefix(GameConsole __instance,
+            RulesetActor character,
+            FeatureDefinition feature,
+            int reductionAmount)
+        {
+            //PATCH: allow damage reduction log to show damage types and show feature description on tooltip
+            var prompt = "Feedback/&DamageReducedLine";
+            var types = "";
+            var typenames = "";
+            if (feature is FeatureDefinitionReduceDamage {DamageTypes.Count: > 0} reduce)
+            {
+                prompt = Gui.Localize("Feedback/&DamageReducedLine").Replace("{2}", "{2}{3}");
+                types = string.Join("", reduce.DamageTypes.Select(x => Gui.FormatDamageType(x)));
+                typenames = string.Join("\n", reduce.DamageTypes.Select(x => Gui.FormatDamageType(x, true)));
+            }
+
+            GameConsoleEntry entry = new GameConsoleEntry(prompt, __instance.consoleTableDefinition) {Indent = true};
+            entry.AddParameter(ConsoleStyleDuplet.ParameterType.AttackSpellPower,
+                Gui.Localize(feature.GuiPresentation.Title), tooltipContent: feature.guiPresentation.Description);
+            __instance.AddCharacterEntry(character, entry);
+            entry.AddParameter(ConsoleStyleDuplet.ParameterType.Positive, reductionAmount.ToString());
+            entry.AddParameter(ConsoleStyleDuplet.ParameterType.Initiative, types, tooltipContent: typenames);
+
+            __instance.AddEntry(entry);
+
+            return false;
         }
     }
 }

--- a/SolastaUnfinishedBusiness/Patches/GameLocationBattleManagerPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/GameLocationBattleManagerPatcher.cs
@@ -681,11 +681,15 @@ public static class GameLocationBattleManagerPatcher
                         throw new ArgumentException("feature.TriggerCondition");
                 }
 
-                var trendInfo = new RuleDefinitions.TrendInfo(totalReducedDamage,
-                    RuleDefinitions.FeatureSourceType.CharacterFeature, feature.FormatTitle(), feature);
+                if (totalReducedDamage <= 0)
+                {
+                    continue;
+                }
 
-                damage.bonusDamage -= totalReducedDamage;
-                damage.DamageBonusTrends.Add(trendInfo);
+                var tag = $"{feature.Name}:{defender.Guid}:{totalReducedDamage}";
+                attackMode?.AttackTags.Add(tag);
+                rulesetEffect?.SourceTags.Add(tag);
+
                 defenderCharacter.DamageReduced(defenderCharacter, feature, totalReducedDamage);
             }
         }

--- a/SolastaUnfinishedBusiness/Patches/RulesetActorPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetActorPatcher.cs
@@ -72,6 +72,7 @@ public static class RulesetActorPatcher
             RollInfo rollInfo
         )
         {
+            //PATCH: suppport for FeatureDefinitionReduceDamage
             var reduction = FeatureDefinitionReduceDamage.DamageReduction(formsParams, rolledDamage, damageType);
             rolledDamage -= reduction;
             rollInfo.modifier -= reduction;

--- a/SolastaUnfinishedBusiness/Patches/RulesetActorPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetActorPatcher.cs
@@ -59,6 +59,25 @@ public static class RulesetActorPatcher
         }
     }
 
+    [HarmonyPatch(typeof(RulesetActor), nameof(RulesetActor.InflictDamage))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class InflictDamage_Patch
+    {
+        [UsedImplicitly]
+        public static void Prefix(
+            ref int rolledDamage,
+            string damageType,
+            RulesetImplementationDefinitions.ApplyFormsParams formsParams,
+            RollInfo rollInfo
+        )
+        {
+            var reduction = FeatureDefinitionReduceDamage.DamageReduction(formsParams, rolledDamage, damageType);
+            rolledDamage -= reduction;
+            rollInfo.modifier -= reduction;
+        }
+    }
+
     [HarmonyPatch(typeof(RulesetActor), nameof(RulesetActor.InflictCondition))]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     [UsedImplicitly]


### PR DESCRIPTION
Reworks how `FeatureDefinitionReduceDamage` reduces damage.

Previously it modified bonus damage of the damage form that triggered that feature which had several problems:
- For AoE spells/powers it could affect damage for other characters
- For AoE spells/powers it could have no effect on the user
- If attack/spell/power had multiple instances of damage only first matching would be reduced, even if reduction was big enough to handle several instanced of damage from same source

New approach modifies damage right before it is inflicted and can track several instances of matching damage types from same attack/spell/power

