### PR TITLE
make divine blade simple, add to sorcerer

### DIFF
--- a/SolastaUnfinishedBusiness/Models/FixesContext.cs
+++ b/SolastaUnfinishedBusiness/Models/FixesContext.cs
@@ -24,6 +24,7 @@ internal static class FixesContext
         FixAdditionalDamageRestrictions();
         FixAttackBuffsAffectingSpellDamage();
         FixColorTables();
+        FixDivineBlade();
         FixFightingStyleArchery();
         FixGorillaWildShapeRocksToUnlimited();
         FixMartialArtsProgression();
@@ -83,6 +84,23 @@ internal static class FixesContext
             Gui.ModifierColors.Add(i, new Color32(0, 164, byte.MaxValue, byte.MaxValue));
             Gui.CheckModifierColors.Add(i, new Color32(0, 36, 77, byte.MaxValue));
         }
+    }
+
+    private static void FixDivineBlade()
+    {
+        //BUGFIX: allows clerics to actually wield divine blade
+        var conjuredSword = WeaponTypeDefinitionBuilder
+            .Create(WeaponTypeDefinitions.LongswordType, "ConjuredSwordType")
+            .SetWeaponCategory(WeaponCategoryDefinitions.SimpleWeaponCategory)
+            .AddToDB();
+
+        var divineBladeWeaponDefinition = ItemDefinitions.DivineBladeWeapon.weaponDefinition;
+        divineBladeWeaponDefinition.weaponType = "ConjuredSwordType";
+
+        ItemDefinitions.DivineBladeWeapon.weaponDefinition = divineBladeWeaponDefinition;
+
+        //BUGFIX: allows divine heart sorcerer to wield divine blade
+        FeatureDefinitionProficiencys.ProficiencySorcererWeapon.proficiencies.Add("ConjuredSwordType");
     }
 
     private static void FixFightingStyleArchery()

--- a/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
+++ b/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
@@ -58,6 +58,9 @@
 
   <ItemGroup>
     <!-- <PackageReference Include="System.Memory" Version="4.5.5" /> -->
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\lib\Assembly-CSharp_public.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
@@ -102,10 +105,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>$(SolutionDir)lib/Assembly-CSharp_public.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(SolastaInstallDir)/Solasta_Data/Managed/Newtonsoft.Json.dll</HintPath>
       <Private>false</Private>


### PR DESCRIPTION
Created a "ConjuredSwordType" weapon type specifically for the Divine Blade spell's summoned blade. Copied longsword, but made it simple, then added it to sorcerer so that Divine Heart subclass can wield it too. If you would rather wait until after TA'
s next patch in case they fix it, then deny this and I will resubmit if necessary.