### PR TITLE
Critical threshold fixes and tweaks

### DIFF
--- a/SolastaUnfinishedBusiness/Feats/CriticalVirtuosoFeats.cs
+++ b/SolastaUnfinishedBusiness/Feats/CriticalVirtuosoFeats.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
 using JetBrains.Annotations;
+using SolastaUnfinishedBusiness.Api;
 using SolastaUnfinishedBusiness.Api.LanguageExtensions;
 using SolastaUnfinishedBusiness.Builders;
+using SolastaUnfinishedBusiness.Builders.Features;
 using SolastaUnfinishedBusiness.CustomValidators;
-using static SolastaUnfinishedBusiness.Api.DatabaseHelper.FeatureDefinitionAttributeModifiers;
 
 namespace SolastaUnfinishedBusiness.Feats;
 
@@ -11,25 +12,40 @@ internal static class CriticalVirtuosoFeats
 {
     internal static void CreateFeats([NotNull] List<FeatDefinition> feats)
     {
+        const string Description = "Feat/&FeatCriticalVirtuosoDescription";
+        var nameImproved = DatabaseHelper.FeatureDefinitionAttributeModifiers
+            .AttributeModifierMartialChampionImprovedCritical.GuiPresentation.Title;
+        var nameSuperior = DatabaseHelper.FeatureDefinitionAttributeModifiers
+            .AttributeModifierMartialChampionSuperiorCritical.GuiPresentation.Title;
+        
+        var improved = FeatureDefinitionAttributeModifierBuilder
+            .Create("AttributeModifierFeatImprovedCritical")
+            .SetGuiPresentation(nameImproved, Description)
+            .SetModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive,
+                AttributeDefinitions.CriticalThreshold, -1)
+            .AddToDB();
+        
+        var superior = FeatureDefinitionAttributeModifierBuilder
+            .Create("AttributeModifierFeatSuperiorCritical")
+            .SetGuiPresentation(nameSuperior, Description)
+            .SetModifier(FeatureDefinitionAttributeModifier.AttributeModifierOperation.Additive,
+                AttributeDefinitions.CriticalThreshold, -1)
+            .AddToDB();
+        
         // Improved Critical
         var featImprovedCritical = FeatDefinitionWithPrerequisitesBuilder
             .Create("FeatImprovedCritical")
-            .SetGuiPresentation("MartialChampionImprovedCritical", Category.Feature)
-            .SetFeatures(AttributeModifierMartialChampionImprovedCritical)
-            .SetValidators(
-                ValidatorsFeat.IsLevel4,
-                ValidatorsFeat.ValidateNotFeature(AttributeModifierMartialChampionImprovedCritical))
+            .SetGuiPresentation(nameImproved, Description)
+            .SetFeatures(improved)
+            .SetValidators(ValidatorsFeat.IsLevel4)
             .AddToDB();
 
         // Superior Critical
         var featSuperiorCritical = FeatDefinitionWithPrerequisitesBuilder
             .Create("FeatSuperiorCritical")
-            .SetGuiPresentation("MartialChampionSuperiorCritical", Category.Feature)
-            .SetFeatures(AttributeModifierMartialChampionSuperiorCritical)
-            .SetValidators(
-                ValidatorsFeat.IsLevel16,
-                ValidatorsFeat.ValidateHasFeature(AttributeModifierMartialChampionImprovedCritical),
-                ValidatorsFeat.ValidateNotFeature(AttributeModifierMartialChampionSuperiorCritical))
+            .SetGuiPresentation(nameSuperior, Description)
+            .SetFeatures(superior)
+            .SetValidators(ValidatorsFeat.IsLevel16, ValidatorsFeat.ValidateHasFeature(improved))
             .AddToDB();
 
         feats.AddRange(featImprovedCritical, featSuperiorCritical);

--- a/SolastaUnfinishedBusiness/Models/FixesContext.cs
+++ b/SolastaUnfinishedBusiness/Models/FixesContext.cs
@@ -36,6 +36,7 @@ internal static class FixesContext
         FixStunningStrikeForAnyMonkWeapon();
         FixTwinnedMetamagic();
         FixUncannyDodgeForRoguishDuelist();
+        FixChampionCriticalThresholdModifiers();
         FixEagerForBattleTexts();
 
         Main.Settings.OverridePartySize = Math.Min(Main.Settings.OverridePartySize, ToolsContext.MaxPartySize);
@@ -262,6 +263,14 @@ internal static class FixesContext
         ActionAffinityUncannyDodge.SetCustomSubFeatures(new ValidatorsDefinitionApplication(
             character => character.GetSubclassLevel(Rogue, RoguishDuelist.Name) < 13 ||
                          character.HasConditionOfType(RoguishDuelist.ConditionReflexiveParry)));
+    }
+
+    private static void FixChampionCriticalThresholdModifiers()
+    {
+        //Changes Champion's Superior Critical to work as described - set crit threshold to 18, instead of lowering by 1
+        var modifier = FeatureDefinitionAttributeModifiers.AttributeModifierMartialChampionSuperiorCritical;
+        modifier.modifierOperation = FeatureDefinitionAttributeModifier.AttributeModifierOperation.Set;
+        modifier.modifierValue = 18;
     }
 
     private static void FixEagerForBattleTexts()

--- a/SolastaUnfinishedBusiness/Patches/RulesetAttributeModifierPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetAttributeModifierPatcher.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using JetBrains.Annotations;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+[UsedImplicitly]
+public static class RulesetAttributeModifierPatcher
+{
+    [HarmonyPatch(typeof(RulesetAttributeModifier), nameof(RulesetAttributeModifier.CompareTo))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class CompareTo_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(RulesetAttributeModifier __instance, ref int __result,
+            RulesetAttributeModifier other)
+        {
+            //PATCH: fixes Critical Threshold SET opertions to apply lowest value
+            if (other == null)
+            {
+                return;
+            }
+
+            if (__instance.Operation != FeatureDefinitionAttributeModifier.AttributeModifierOperation.Set)
+            {
+                return;
+            }
+            
+            var priorityCache = RulesetAttributeModifier.AttributeModifierOperationPriorityCache;
+            if (priorityCache[(int)__instance.Operation] != priorityCache[(int)other.Operation])
+            {
+                return;
+            }
+
+            if (__instance.Tags.Contains("SetLowest"))
+            {
+                __result = -__instance.Value.CompareTo(other.Value);
+            }
+
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Patches/RulesetAttributePatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetAttributePatcher.cs
@@ -1,0 +1,26 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using JetBrains.Annotations;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+[UsedImplicitly]
+public static class RulesetAttributePatcher
+{
+    [HarmonyPatch(typeof(RulesetAttribute), nameof(RulesetAttribute.AddModifier))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class AddModifier_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(RulesetAttribute __instance, RulesetAttributeModifier modifier)
+        {
+            //PATCH: fixes Critical Threshold SET opertions to apply lowest value
+            if (__instance.Name == AttributeDefinitions.CriticalThreshold
+                && modifier.Operation == FeatureDefinitionAttributeModifier.AttributeModifierOperation.Set)
+            {
+                modifier.Tags.TryAdd("SetLowest");
+            }
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Translations/en/Feats/OtherFeats-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Feats/OtherFeats-en.txt
@@ -2,6 +2,7 @@ Condition/&ConditionFeatMobileAfterDashDescription=Grants immunity to movement r
 Condition/&ConditionFeatMobileAfterDashTitle=Freedom
 Feat/&FeatAstralArmsDescription=Increase your Wisdom by 1, to a maximum of 20.\nWhen you make an unarmed strike on your turn, your reach for it is 10 ft. Other creatures provoke an opportunity attack from you when they enter the reach you have with unarmed.
 Feat/&FeatAstralArmsTitle=Astral Reach
+Feat/&FeatCriticalVirtuosoDescription=Your critical threshold is lowered by 1.
 Feat/&FeatEldritchAdeptDescription=You learn one Eldritch Invocation option of your choice from the warlock class. If the invocation has a prerequisite, you can choose that invocation only if you're a warlock and only if you meet the prerequisite. Whenever you gain a level, you can replace the invocation with another one from the warlock class.
 Feat/&FeatEldritchAdeptTitle=Eldritch Adept
 Feat/&FeatElementalAdeptDescription={0} damage type spells you cast ignore target's resistance to damage. In addition, when you roll damage for these spells, you can reroll any 1s.


### PR DESCRIPTION
- Fixed Critical Threshold SET modifiers applying highest, instead of lowest value
- Fixed Champion's Superior Critical reducing Critical Threshold by 1 instead of setting to 18
- Made Critical Virtuoso feats lower Critical Threshold by 1 to allow stacking with other features