### PR TITLE
Fix Ability of the Chain Master Pseudo Dragon inflicting unsavable pa…

### DIFF
--- a/SolastaUnfinishedBusiness/CustomBuilders/InvocationsBuilders.cs
+++ b/SolastaUnfinishedBusiness/CustomBuilders/InvocationsBuilders.cs
@@ -523,7 +523,13 @@ internal static class InvocationsBuilders
         var conditionAbilityPseudo = ConditionDefinitionBuilder
             .Create(ConditionDefinitions.ConditionFlying12, "ConditionAbilityPseudo")
             .SetGuiPresentation(Category.Condition, ConditionDefinitions.ConditionPactChainPseudodragon)
-            .AddFeatures(FeatureDefinitionAdditionalDamages.AdditionalDamagePoison_GhoulsCaress)
+            .AddFeatures(
+                FeatureDefinitionAdditionalDamageBuilder.Create(
+                    FeatureDefinitionAdditionalDamages.AdditionalDamagePoison_GhoulsCaress, "AdditionalDamagePseudoDragon")
+                    .SetSavingThrowData(EffectDifficultyClassComputation.SpellCastingFeature, EffectSavingThrowType.HalfDamage, AttributeDefinitions.Constitution)
+                    .SetDamageDice(DieType.D8, 1)
+                    .AddToDB()
+            )
             .SetSilent(Silent.WhenAddedOrRemoved)
             .AddToDB();
 

--- a/SolastaUnfinishedBusiness/CustomBuilders/InvocationsBuilders.cs
+++ b/SolastaUnfinishedBusiness/CustomBuilders/InvocationsBuilders.cs
@@ -528,6 +528,7 @@ internal static class InvocationsBuilders
                     FeatureDefinitionAdditionalDamages.AdditionalDamagePoison_GhoulsCaress, "AdditionalDamagePseudoDragon")
                     .SetSavingThrowData(EffectDifficultyClassComputation.SpellCastingFeature, EffectSavingThrowType.HalfDamage, AttributeDefinitions.Constitution)
                     .SetDamageDice(DieType.D8, 1)
+                    .SetNotificationTag("Poison")
                     .AddToDB()
             )
             .SetSilent(Silent.WhenAddedOrRemoved)

--- a/SolastaUnfinishedBusiness/Subclasses/PatronEldritchSurge.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PatronEldritchSurge.cs
@@ -206,7 +206,7 @@ internal class PatronEldritchSurge : AbstractSubclass
             var increaseLevels = new[] { 3, 8, 13, 18 };
             var additionalBeamCount = increaseLevels.Count(level => determinantLevel >= level);
             var pursuitStatus = rulesetCharacter.HasConditionOfType(ConditionBlastPursuit)
-                ? 1 + warlockClassLevel >= 16 ? 1 : 0
+                ? (1 + (warlockClassLevel >= 16 ? 1 : 0))
                 : 0;
             var overloadStatus = rulesetCharacter.HasConditionOfType(ConditionBlastOverload) ? 1 : 0;
 


### PR DESCRIPTION
…ralyze.

Modify it from fixed dc to spell dc

Note: After careful inspection the remove of
```
formsParams.activeEffect == null &&
```
has no other implications.
This is indeed a logic bug in vanilla game. When creating EffectForm there are detailed modifications to them, but when applying ConditionForm this method simply override saving info from the formsParam, which is not correct because this ignores subfeature overrides