### PR TITLE
Serializable Custom Conditions

### DIFF
--- a/SolastaUnfinishedBusiness/Api/LanguageExtensions/TypeExtensions.cs
+++ b/SolastaUnfinishedBusiness/Api/LanguageExtensions/TypeExtensions.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SolastaUnfinishedBusiness.Api.LanguageExtensions;
+
+/*
+    Courtery to https://stackoverflow.com/questions/4035719/getmethod-for-generic-method
+    A powerful GetMethod that handles matching one of the overloads including generic type params
+ */
+
+internal static class TypeExtensions
+{
+    /// <summary>
+    /// Search for a method by name and parameter types.  
+    /// Unlike GetMethod(), does 'loose' matching on generic
+    /// parameter types, and searches base interfaces.
+    /// </summary>
+    /// <exception cref="AmbiguousMatchException"/>
+    internal static MethodInfo GetMethodExt(this Type thisType,
+                                            string name,
+                                            params Type[] parameterTypes)
+    {
+        return GetMethodExt(thisType,
+                            name,
+                            BindingFlags.Instance
+                            | BindingFlags.Static
+                            | BindingFlags.Public
+                            | BindingFlags.NonPublic
+                            | BindingFlags.FlattenHierarchy,
+                            parameterTypes);
+    }
+
+    /// <summary>
+    /// Search for a method by name, parameter types, and binding flags.  
+    /// Unlike GetMethod(), does 'loose' matching on generic
+    /// parameter types, and searches base interfaces.
+    /// </summary>
+    /// <exception cref="AmbiguousMatchException"/>
+    internal static MethodInfo GetMethodExt(this Type thisType,
+                                            string name,
+                                            BindingFlags bindingFlags,
+                                            params Type[] parameterTypes)
+    {
+        MethodInfo matchingMethod = null;
+
+        // Check all methods with the specified name, including in base classes
+        GetMethodExt(ref matchingMethod, thisType, name, bindingFlags, parameterTypes);
+
+        // If we're searching an interface, we have to manually search base interfaces
+        if (matchingMethod == null && thisType.IsInterface)
+        {
+            foreach (var interfaceType in thisType.GetInterfaces())
+                GetMethodExt(ref matchingMethod,
+                             interfaceType,
+                             name,
+                             bindingFlags,
+                             parameterTypes);
+        }
+
+        return matchingMethod;
+    }
+
+    private static void GetMethodExt(ref MethodInfo matchingMethod,
+                                        Type type,
+                                        string name,
+                                        BindingFlags bindingFlags,
+                                        params Type[] parameterTypes)
+    {
+        // Check all methods with the specified name, including in base classes
+        foreach (MethodInfo methodInfo in type.GetMember(name,
+                                                         MemberTypes.Method,
+                                                         bindingFlags))
+        {
+            // Check that the parameter counts and types match, 
+            // with 'loose' matching on generic parameters
+            var parameterInfos = methodInfo.GetParameters();
+            if (parameterInfos.Length == parameterTypes.Length)
+            {
+                var i = 0;
+                for (; i < parameterInfos.Length; ++i)
+                {
+                    if (!parameterInfos[i].ParameterType
+                                          .IsSimilarType(parameterTypes[i]))
+                        break;
+                }
+                if (i == parameterInfos.Length)
+                {
+                    if (matchingMethod == null)
+                        matchingMethod = methodInfo;
+                    else
+                        throw new AmbiguousMatchException(
+                               "More than one matching method found!");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Special type used to match any generic parameter type in GetMethodExt().
+    /// </summary>
+    internal class T
+    { }
+
+    /// <summary>
+    /// Determines if the two types are either identical, or are both generic 
+    /// parameters or generic types with generic parameters in the same
+    ///  locations (generic parameters match any other generic paramter,
+    /// but NOT concrete types).
+    /// </summary>
+    internal static bool IsSimilarType(this Type thisType, Type type)
+    {
+        // Ignore any 'ref' types
+        if (thisType.IsByRef)
+            thisType = thisType.GetElementType();
+        if (type.IsByRef)
+            type = type.GetElementType();
+
+        // Handle array types
+        if (thisType.IsArray && type.IsArray)
+            return thisType.GetElementType().IsSimilarType(type.GetElementType());
+
+        // If the types are identical, or they're both generic parameters 
+        // or the special 'T' type, treat as a match
+        if (thisType == type || (thisType.IsGenericParameter || thisType == typeof(T))
+                             && (type.IsGenericParameter || type == typeof(T)))
+            return true;
+
+        // Handle any generic arguments
+        if (thisType.IsGenericType && type.IsGenericType)
+        {
+            var thisArguments = thisType.GetGenericArguments();
+            var arguments = type.GetGenericArguments();
+            if (thisArguments.Length == arguments.Length)
+            {
+                for (var i = 0; i < thisArguments.Length; ++i)
+                {
+                    if (!thisArguments[i].IsSimilarType(arguments[i]))
+                        return false;
+                }
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/SolastaUnfinishedBusiness/Patches/RulesetActorPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetActorPatcher.cs
@@ -9,6 +9,7 @@ using JetBrains.Annotations;
 using SolastaUnfinishedBusiness.Api;
 using SolastaUnfinishedBusiness.Api.GameExtensions;
 using SolastaUnfinishedBusiness.Api.Helpers;
+using SolastaUnfinishedBusiness.Api.LanguageExtensions;
 using SolastaUnfinishedBusiness.CustomBehaviors;
 using SolastaUnfinishedBusiness.CustomDefinitions;
 using SolastaUnfinishedBusiness.CustomInterfaces;
@@ -19,6 +20,7 @@ using TA;
 using UnityEngine;
 using static ConsoleStyleDuplet;
 using static FeatureDefinitionAttributeModifier;
+using static SolastaUnfinishedBusiness.Api.LanguageExtensions.TypeExtensions;
 
 namespace SolastaUnfinishedBusiness.Patches;
 
@@ -781,6 +783,32 @@ public static class RulesetActorPatcher
                 newEffectForms, formsParams, effectiveDamageTypes,
                 out damageAbsorbedByTemporaryHitPoints, out terminateEffectOnTarget,
                 retargeting, proxyOnly, forceSelfConditionOnly, effectApplication, filters);
+        }
+    }
+
+    [HarmonyPatch(typeof(RulesetActor), nameof(RulesetActor.SerializeElements))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class SerializeElements_Patch
+    {
+        [UsedImplicitly]
+        public static IEnumerable<CodeInstruction> Transpiler([NotNull] IEnumerable<CodeInstruction> instructions)
+        {
+            //PATCH: supports class inheriting RulesetCondition for saving serializable data
+            //change
+            //this.conditionsByCategory = serializer.SerializeElement<string, List<RulesetCondition>>("ConditionsByCategory", this.conditionsByCategory);
+            //to
+            //this.conditionsByCategory = serializer.SerializeElement<string, List<RulesetCondition>>("ConditionsByCategory", this.conditionsByCategory, Serializer.SerializationOption.SerializeTypeName);
+            var originalMethod = typeof(IElementsSerializer).GetMethodExt("SerializeElement",
+                new Type[] { typeof(string), typeof(Dictionary<, >) }).MakeGenericMethod(typeof(string), typeof(List<RulesetCondition>));
+            var replacingMethod = typeof(IElementsSerializer).GetMethodExt("SerializeElement",
+                new Type[] { typeof(string), typeof(Dictionary<, >), typeof(Serializer.SerializationOption)}).MakeGenericMethod(typeof(string), typeof(List<RulesetCondition>));
+
+            return instructions.ReplaceCalls(
+                originalMethod,
+                "RulesetActor.SerializeElements",
+                new CodeInstruction(OpCodes.Ldc_I4_1),
+                new CodeInstruction(OpCodes.Callvirt, replacingMethod));
         }
     }
 }

--- a/SolastaUnfinishedBusiness/Subclasses/PatronEldritchSurge.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PatronEldritchSurge.cs
@@ -531,14 +531,7 @@ internal class PatronEldritchSurge : AbstractSubclass
                 BaseDefinition.SerializeDatabaseReferenceList<SpellDefinition>(serializer, "CantripsUsedThisTurn", "SpellDefinition", cantripsUsedThisTurn);
                 if (serializer.Mode == Serializer.SerializationMode.Read)
                 {
-                    for (int i = 0; i < this.cantripsUsedThisTurn.Count; i++)
-                    {
-                        if (this.cantripsUsedThisTurn[i] == null)
-                        {
-                            this.cantripsUsedThisTurn.RemoveAt(i);
-                            i--;
-                        }
-                    }
+                    cantripsUsedThisTurn.RemoveAll(x => x is null);
                 }
             }
             catch (Exception ex)

--- a/SolastaUnfinishedBusiness/Subclasses/PatronEldritchSurge.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PatronEldritchSurge.cs
@@ -94,6 +94,11 @@ internal class PatronEldritchSurge : AbstractSubclass
 
     // LEVEL 14 Blast Reload
 
+    private static readonly ConditionDefinition ConditionBlastReloadSupport = ConditionDefinitionBuilder
+        .Create($"Condition{Name}BlastReloadSupport")
+        .SetGuiPresentationNoContent(true)
+        .AddToDB();
+
     public static readonly FeatureDefinition FeatureBlastReload = FeatureDefinitionBuilder
         .Create($"Feature{Name}BlastReload")
         .SetGuiPresentation(Category.Feature)
@@ -440,16 +445,14 @@ internal class PatronEldritchSurge : AbstractSubclass
     private sealed class CustomBehaviorBlastReload :
         IActionExecutionHandled, ICharacterTurnStartListener, IQualifySpellToRepertoireLine
     {
-        // use a map to ensure any collateral scenarios with other warlocks casting cantrips on this warlock turn
-        private readonly Dictionary<RulesetCharacter, List<SpellDefinition>> _cantripsUsedThisTurn = new();
-
         public void OnActionExecutionHandled(
             GameLocationCharacter gameLocationCharacter,
             CharacterActionParams actionParams,
             ActionScope scope)
         {
             // only collect cantrips
-            if (actionParams.activeEffect is not RulesetEffectSpell rulesetEffectSpell ||
+            if (scope != ActionScope.Battle ||
+                actionParams.activeEffect is not RulesetEffectSpell rulesetEffectSpell ||
                 rulesetEffectSpell.SpellDefinition.SpellLevel != 0)
             {
                 return;
@@ -459,19 +462,39 @@ internal class PatronEldritchSurge : AbstractSubclass
             var rulesetCharacter = gameLocationCharacter.RulesetCharacter;
 
             if (rulesetCharacter is not { IsDeadOrDyingOrUnconscious: false } ||
-                rulesetCharacter.GetSubclassLevel(CharacterClassDefinitions.Warlock, Name) < 14)
+                rulesetCharacter.GetOriginalHero().GetSubclassLevel(CharacterClassDefinitions.Warlock, Name) < 14)
             {
                 return;
             }
 
-            _cantripsUsedThisTurn.TryAdd(rulesetCharacter, new List<SpellDefinition>());
-            _cantripsUsedThisTurn[rulesetCharacter].TryAdd(rulesetEffectSpell.SpellDefinition);
+            if (!rulesetCharacter.TryGetConditionOfCategoryAndType("10Combat",ConditionBlastReloadSupport.Name, out var supportCondition))
+            {
+                supportCondition = CreateCustomCondition<BlastReloadSupportRulesetCondition>(rulesetCharacter.guid, ConditionBlastReloadSupport);
+                rulesetCharacter.AddConditionOfCategory("10Combat", supportCondition, true, true);
+            }
+
+            var eldritchSurgeSupportCondition = supportCondition as BlastReloadSupportRulesetCondition;
+            eldritchSurgeSupportCondition.CantripsUsedThisTurn.TryAdd(rulesetEffectSpell.SpellDefinition);
         }
 
-        public void OnCharacterTurnStarted(GameLocationCharacter locationCharacter)
+        public void OnCharacterTurnStarted(GameLocationCharacter gameLocationCharacter)
         {
-            // clean up cantrips map on every turn start
-            _cantripsUsedThisTurn.Clear();
+            // clean up cantrips list on every turn start
+            // combat condition will be removed automatically after combat
+            var rulesetCharacter = gameLocationCharacter.RulesetCharacter;
+
+            if (rulesetCharacter is not { IsDeadOrDyingOrUnconscious: false } ||
+                rulesetCharacter.GetOriginalHero().GetSubclassLevel(CharacterClassDefinitions.Warlock, Name) < 14)
+            {
+                return;
+            }
+
+            if (rulesetCharacter.TryGetConditionOfCategoryAndType("10Combat", ConditionBlastReloadSupport.Name, out var supportCondition))
+            {
+                var eldritchSurgeSupportCondition = supportCondition as BlastReloadSupportRulesetCondition;
+                eldritchSurgeSupportCondition.CantripsUsedThisTurn.Clear();
+            }
+
         }
 
         public void QualifySpells(
@@ -480,13 +503,90 @@ internal class PatronEldritchSurge : AbstractSubclass
             IEnumerable<SpellDefinition> spells)
         {
             // _cantripsUsedThisTurn only has entries for Eldritch Surge of at least level 14
-            if (spellRepertoireLine.actionType != ActionType.Bonus ||
-                !_cantripsUsedThisTurn.TryGetValue(rulesetCharacter, out var cantrips))
+            if (spellRepertoireLine.actionType == ActionType.Bonus &&
+                rulesetCharacter.TryGetConditionOfCategoryAndType("10Combat", ConditionBlastReloadSupport.Name, out var supportCondition))
             {
-                return;
+                var eldritchSurgeSupportCondition = supportCondition as BlastReloadSupportRulesetCondition;
+                spellRepertoireLine.relevantSpells.AddRange(eldritchSurgeSupportCondition.CantripsUsedThisTurn.Intersect(spells));
             }
-
-            spellRepertoireLine.relevantSpells.AddRange(cantrips.Intersect(spells));
         }
+    }
+    internal class BlastReloadSupportRulesetCondition : RulesetCondition, ISerializable
+    {
+
+        private List<SpellDefinition> cantripsUsedThisTurn = new List<SpellDefinition>();
+
+        public List<SpellDefinition> CantripsUsedThisTurn { get => cantripsUsedThisTurn; set => cantripsUsedThisTurn = value; }
+
+        public override void SerializeAttributes(IAttributesSerializer serializer, IVersionProvider versionProvider)
+        {
+            base.SerializeAttributes(serializer, versionProvider);
+        }
+
+        public override void SerializeElements(IElementsSerializer serializer, IVersionProvider versionProvider)
+        {
+            base.SerializeElements(serializer, versionProvider);
+            try
+            {
+                BaseDefinition.SerializeDatabaseReferenceList<SpellDefinition>(serializer, "CantripsUsedThisTurn", "SpellDefinition", cantripsUsedThisTurn);
+                if (serializer.Mode == Serializer.SerializationMode.Read)
+                {
+                    for (int i = 0; i < this.cantripsUsedThisTurn.Count; i++)
+                    {
+                        if (this.cantripsUsedThisTurn[i] == null)
+                        {
+                            this.cantripsUsedThisTurn.RemoveAt(i);
+                            i--;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.LogException(new Exception("[TACTICAL INVISIBLE FOR PLAYERS] error with EldritchSurgeSupportCondition serialization (may be caused by mods or bad versioning implementation) " + ex.Message, ex));
+                Gui.GuiService.ShowMessage(MessageModal.Severity.Serious3, "Message/&CorruptedCharacterErrorTitle", "Message/&CorruptedCharacterErrorDescription", "Message/&MessageOkTitle", null, null, null, true, false, false, false);
+            }
+        }
+    }
+
+    // place this method elsewhere fit
+    public static T CreateCustomCondition<T>(
+            ulong targetGuid,
+            ConditionDefinition conditionDefinition,
+            int effectLevel = 1,
+            int amount = 0,
+            int sourceAbilityBonus = 0,
+            int sourceProficiencyBonus = 0) where T : RulesetCondition, new()
+    {
+        T rulesetCondition = new T();
+        rulesetCondition.ResetGuid();
+        rulesetCondition.Clear();
+        rulesetCondition.targetGuid = targetGuid;
+        if (conditionDefinition.SpecialDuration)
+        {
+            rulesetCondition.durationType = conditionDefinition.DurationType;
+            rulesetCondition.durationParameter = RuleDefinitions.RollStaticDiceAndSum(conditionDefinition.DurationParameter, conditionDefinition.DurationParameterDie, null);
+            rulesetCondition.remainingRounds = RuleDefinitions.ComputeRoundsDuration(rulesetCondition.durationType, rulesetCondition.durationParameter);
+        }
+        else
+        {
+            rulesetCondition.durationType = RuleDefinitions.DurationType.Irrelevant;
+            rulesetCondition.durationParameter = 0;
+            rulesetCondition.remainingRounds = 0;
+        }
+        rulesetCondition.endOccurence = RuleDefinitions.TurnOccurenceType.EndOfTurn;
+        rulesetCondition.ConditionDefinition = conditionDefinition;
+        rulesetCondition.sourceGuid = 0UL;
+        rulesetCondition.sourceFactionName = string.Empty;
+        rulesetCondition.effectLevel = effectLevel;
+        rulesetCondition.effectDefinitionName = string.Empty;
+        if (conditionDefinition.AmountOrigin != ConditionDefinition.OriginOfAmount.None)
+        {
+            rulesetCondition.amount = amount;
+        }
+        rulesetCondition.sourceAbilityBonus = sourceAbilityBonus;
+        rulesetCondition.sourceProficiencyBonus = sourceProficiencyBonus;
+        rulesetCondition.doNotTerminateWhenRemoved = false;
+        return rulesetCondition;
     }
 }


### PR DESCRIPTION
Currently many homebrew features require storing some dynamic variables to compute for different purposes. And to make them persistent in game save, we just like stack conditions and count number, which is just not so versatile.
With patching in serialization process in RulesetActor, it now supports serialize objects inheriting RulesetCondition. This is an existing practice elsewhere in vanilla game.
So now if you have some condition variables (int, string, whatever) to store, you just create a dummy ConditionDefinition for reference and a new class inheriting RulesetCondition and ISerializable, implementing two serialization functions to to serialize your newly added properties, that's done.
we can copy/paste InflictCondition to make it usages similar to old practice, like append another param to initialize custom condition properties.
Have no impact on current saves. 
Hoping this utility helps with bolder imagination.