### PR TITLE
Fixed an error with the 'GetNextControlledCharacterInInitiative' method

### DIFF
--- a/SolastaUnfinishedBusiness/CustomUI/Tooltips.cs
+++ b/SolastaUnfinishedBusiness/CustomUI/Tooltips.cs
@@ -211,7 +211,10 @@ internal static class Tooltips
         return Math.Max(Math.Max(Math.Abs(rawDistance.x), Math.Abs(rawDistance.z)), Math.Abs(rawDistance.y));
     }
 
-    private static GameLocationCharacter GetNextControlledCharacterInInitiative(List<GameLocationCharacter> initiativeSortedContenders, PlayerController activePlayerController, GameLocationCharacter actingCharacter)
+    private static GameLocationCharacter GetNextControlledCharacterInInitiative(
+        List<GameLocationCharacter> initiativeSortedContenders,
+        PlayerController activePlayerController,
+        GameLocationCharacter actingCharacter)
         => initiativeSortedContenders.Find(character =>
             character.controllerId == activePlayerController.controllerId
             && character.lastInitiative < actingCharacter.lastInitiative) ?? initiativeSortedContenders.Find(character =>

--- a/SolastaUnfinishedBusiness/CustomUI/Tooltips.cs
+++ b/SolastaUnfinishedBusiness/CustomUI/Tooltips.cs
@@ -211,15 +211,11 @@ internal static class Tooltips
         return Math.Max(Math.Max(Math.Abs(rawDistance.x), Math.Abs(rawDistance.z)), Math.Abs(rawDistance.y));
     }
 
-    private static GameLocationCharacter GetNextControlledCharacterInInitiative(
-        List<GameLocationCharacter> initiativeSortedContenders,
-        PlayerController activePlayerController,
-        GameLocationCharacter actingCharacter)
-    {
-        return initiativeSortedContenders.Find(character =>
+    private static GameLocationCharacter GetNextControlledCharacterInInitiative(List<GameLocationCharacter> initiativeSortedContenders, PlayerController activePlayerController, GameLocationCharacter actingCharacter)
+        => initiativeSortedContenders.Find(character =>
             character.controllerId == activePlayerController.controllerId
-            && character.lastInitiative < actingCharacter.lastInitiative);
-    }
+            && character.lastInitiative < actingCharacter.lastInitiative) ?? initiativeSortedContenders.Find(character =>
+            character.controllerId == activePlayerController.controllerId);
 
     private static void UpdateDistanceText(int distance, GameLocationCharacter characterToMeasureFrom)
     {


### PR DESCRIPTION
Fixed an error where if you had no controlled character left to play in the current initiative, and you hovered on a creature, the method 'GetNextControlledCharacterInInitiative' wold return null and cause a NullReferenceException