### PR TITLE
Fix custom character sizes

### DIFF
--- a/SolastaUnfinishedBusiness/CustomUI/Tooltips.cs
+++ b/SolastaUnfinishedBusiness/CustomUI/Tooltips.cs
@@ -147,6 +147,26 @@ internal static class Tooltips
             {
                 _distanceTextObject.SetActive(true);
             }
+
+            var characterVector3 = new Vector3(characterToMeasureFrom.LocationPosition.x,
+                characterToMeasureFrom.LocationPosition.y,
+                characterToMeasureFrom.LocationPosition.z);
+
+            var hoveredCharacterVector3 = new Vector3(
+                ServiceRepository.GetService<IGameLocationSelectionService>().HoveredCharacters[0].LocationPosition.x,
+                ServiceRepository.GetService<IGameLocationSelectionService>().HoveredCharacters[0].LocationPosition.y,
+                ServiceRepository.GetService<IGameLocationSelectionService>().HoveredCharacters[0].LocationPosition.z);
+            
+            var isCellPerceivedByCharacter = ServiceRepository.GetService<IGameLocationVisibilityService>().IsCellPerceivedByCharacter(
+                ServiceRepository.GetService<IGameLocationSelectionService>().HoveredCharacters[0].LocationPosition,
+                characterToMeasureFrom);
+            
+            var isPositionPerceivedByCharacter = ServiceRepository.GetService<IGameLocationVisibilityService>().IsPositionPerceivedByCharacter(
+                hoveredCharacterVector3,
+                characterVector3,
+                characterToMeasureFrom.RulesetCharacter);
+            
+            Debug.DrawLine(characterVector3, ServiceRepository.GetService<ICursorService>().CurrentCursor.transform.position, Color.red);
         }
         else if (!Main.Settings.EnableDistanceOnTooltip || battleService.Battle is null)
         {

--- a/SolastaUnfinishedBusiness/CustomUI/Tooltips.cs
+++ b/SolastaUnfinishedBusiness/CustomUI/Tooltips.cs
@@ -147,26 +147,6 @@ internal static class Tooltips
             {
                 _distanceTextObject.SetActive(true);
             }
-
-            var characterVector3 = new Vector3(characterToMeasureFrom.LocationPosition.x,
-                characterToMeasureFrom.LocationPosition.y,
-                characterToMeasureFrom.LocationPosition.z);
-
-            var hoveredCharacterVector3 = new Vector3(
-                ServiceRepository.GetService<IGameLocationSelectionService>().HoveredCharacters[0].LocationPosition.x,
-                ServiceRepository.GetService<IGameLocationSelectionService>().HoveredCharacters[0].LocationPosition.y,
-                ServiceRepository.GetService<IGameLocationSelectionService>().HoveredCharacters[0].LocationPosition.z);
-            
-            var isCellPerceivedByCharacter = ServiceRepository.GetService<IGameLocationVisibilityService>().IsCellPerceivedByCharacter(
-                ServiceRepository.GetService<IGameLocationSelectionService>().HoveredCharacters[0].LocationPosition,
-                characterToMeasureFrom);
-            
-            var isPositionPerceivedByCharacter = ServiceRepository.GetService<IGameLocationVisibilityService>().IsPositionPerceivedByCharacter(
-                hoveredCharacterVector3,
-                characterVector3,
-                characterToMeasureFrom.RulesetCharacter);
-            
-            Debug.DrawLine(characterVector3, ServiceRepository.GetService<ICursorService>().CurrentCursor.transform.position, Color.red);
         }
         else if (!Main.Settings.EnableDistanceOnTooltip || battleService.Battle is null)
         {

--- a/SolastaUnfinishedBusiness/Races/Bolgrif.cs
+++ b/SolastaUnfinishedBusiness/Races/Bolgrif.cs
@@ -87,10 +87,10 @@ internal static class RaceBolgrifBuilder
             .SetGuiPresentation(Category.Race, bolgrifSpriteReference)
             .SetSizeDefinition(CharacterSizeDefinitions.Medium)
             .SetRacePresentation(bolgrifRacePresentation)
+            .SetBaseHeight(90)
+            .SetBaseWeight(280)
             .SetMinimalAge(30)
             .SetMaximalAge(500)
-            .SetBaseHeight(84)
-            .SetBaseWeight(170)
             .SetFeaturesAtLevel(1,
                 attributeModifierBolgrifStrengthAbilityScoreIncrease,
                 attributeModifierBolgrifWisdomAbilityScoreIncrease,

--- a/SolastaUnfinishedBusiness/Races/Fairy.cs
+++ b/SolastaUnfinishedBusiness/Races/Fairy.cs
@@ -141,9 +141,9 @@ internal static class RaceFairyBuilder
             .Create(Elf, "RaceFairy")
             .SetGuiPresentation(Category.Race, Sprites.GetSprite(Name, Resources.Fairy, 1024, 512))
             .SetSizeDefinition(CharacterSizeDefinitions.Small)
-            .SetBaseWeight(35)
-            .SetBaseHeight(1)
-            .SetMinimalAge(6)
+            .SetBaseHeight(24)
+            .SetBaseWeight(25)
+            .SetMinimalAge(18)
             .SetMaximalAge(120)
             .SetFeaturesAtLevel(1,
                 castSpellFairy,

--- a/SolastaUnfinishedBusiness/Races/Kobold.cs
+++ b/SolastaUnfinishedBusiness/Races/Kobold.cs
@@ -35,8 +35,8 @@ internal static class RaceKoboldBuilder
             .Create(Dragonborn, "RaceKobold")
             .SetGuiPresentation(Category.Race, koboldSpriteReference)
             .SetSizeDefinition(CharacterSizeDefinitions.Small)
-            .SetBaseWeight(35)
-            .SetBaseHeight(3)
+            .SetBaseHeight(30)
+            .SetBaseWeight(30)
             .SetMinimalAge(6)
             .SetMaximalAge(120)
             .SetFeaturesAtLevel(1,

--- a/SolastaUnfinishedBusiness/Races/Oligath.cs
+++ b/SolastaUnfinishedBusiness/Races/Oligath.cs
@@ -74,10 +74,10 @@ internal static class RaceOligathBuilder
             .SetGuiPresentation(Category.Race, Sprites.GetSprite(Name, Resources.Oligath, 1024, 512))
             .SetSizeDefinition(CharacterSizeDefinitions.Medium)
             .SetRacePresentation(Elf.RacePresentation.DeepCopy())
-            .SetBaseWeight(35)
-            .SetBaseHeight(3)
-            .SetMinimalAge(6)
-            .SetMaximalAge(120)
+            .SetBaseHeight(90)
+            .SetBaseWeight(310)
+            .SetMinimalAge(18)
+            .SetMaximalAge(80)
             .SetFeaturesAtLevel(1,
                 attributeModifierOligathStrengthAbilityScoreIncrease,
                 attributeModifierOligathConstitutionAbilityScoreIncrease,

--- a/SolastaUnfinishedBusiness/Races/Wendigo.cs
+++ b/SolastaUnfinishedBusiness/Races/Wendigo.cs
@@ -86,10 +86,10 @@ internal static class RaceWendigoBuilder
             .SetGuiPresentation(Category.Race, Sprites.GetSprite(Name, Resources.Wendigo, 1024, 512))
             .SetSizeDefinition(CharacterSizeDefinitions.Medium)
             .SetRacePresentation(racePresentation)
-            .SetBaseWeight(35)
-            .SetBaseHeight(3)
-            .SetMinimalAge(6)
-            .SetMaximalAge(80)
+            .SetBaseHeight(96)
+            .SetBaseWeight(260)
+            .SetMinimalAge(20)
+            .SetMaximalAge(200)
             .SetFeaturesAtLevel(1,
                 FeatureDefinitionSenses.SenseNormalVision,
                 FeatureDefinitionSenses.SenseDarkvision,

--- a/SolastaUnfinishedBusiness/Races/Wyrmkin.cs
+++ b/SolastaUnfinishedBusiness/Races/Wyrmkin.cs
@@ -42,10 +42,10 @@ internal static class RaceWyrmkinBuilder
             .Create(Dragonborn, RaceName)
             .SetGuiPresentation(Category.Race, Sprites.GetSprite(RaceName, Resources.Wyrmkin, 1024, 512))
             .SetSizeDefinition(CharacterSizeDefinitions.Medium)
-            .SetBaseWeight(35)
-            .SetBaseHeight(3)
-            .SetMinimalAge(6)
-            .SetMaximalAge(200)
+            .SetBaseHeight(72)
+            .SetBaseWeight(185)
+            .SetMinimalAge(18)
+            .SetMaximalAge(750)
             .SetFeaturesAtLevel(1,
                 MoveModeMove6,
                 SenseNormalVision,


### PR DESCRIPTION
Fixed an error where if you had no controlled character left to play in the current initiative, and you hovered on a creature, the method 'GetNextControlledCharacterInInitiative' wold return null and cause a NullReferenceException