### PR TITLE
For suspended flight, add option to use official Winged Boots rules

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/GameUiDisplay.cs
@@ -215,6 +215,16 @@ internal static class GameUiDisplay
         if (UI.Toggle(Gui.Localize("ModUi/&AllowFlightSuspend"), ref toggle, UI.AutoWidth()))
         {
             Main.Settings.AllowFlightSuspend = toggle;
+
+        }
+
+        if (Main.Settings.AllowFlightSuspend)
+        {
+            toggle = Main.Settings.FlightSuspendWingedBoots;
+            if (UI.Toggle(Gui.Localize("ModUi/&FlightSuspendWingedBoots"), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.FlightSuspendWingedBoots = toggle;
+            }
         }
 
         UI.Label();

--- a/SolastaUnfinishedBusiness/Models/CustomConditionsContext.cs
+++ b/SolastaUnfinishedBusiness/Models/CustomConditionsContext.cs
@@ -496,6 +496,14 @@ internal static class CustomConditionsContext
                     rulesetCondition.targetGuid = target.Guid;
                     rulesetCondition.remainingRounds = condition.remainingRounds;
                     rulesetCondition.endOccurence = condition.endOccurence;
+
+                    if (Main.Settings.FlightSuspendWingedBoots
+                            && condition.Name == "ConditionFlyingBootsWinged")
+                    {
+                        //Stop duration counting for Winged Boots
+                        rulesetCondition.durationType = DurationType.Permanent;
+                    }
+
                     break;
                 }
             }

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -156,6 +156,7 @@ public class Settings : UnityModManager.ModSettings
     public bool UseOfficialDistanceCalculation { get; set; }
     public bool DontEndTurnAfterReady { get; set; }
     public bool AllowFlightSuspend { get; set; }
+    public bool FlightSuspendWingedBoots { get; set; }
     public bool IdentifyAfterRest { get; set; }
     public bool AddBleedingToLesserRestoration { get; set; }
     public bool BlindedConditionDontAllowAttackOfOpportunity { get; set; }

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -21,6 +21,7 @@ ModUi/&AllowClubsToBeThrown=Allow <color=#D89555>clubs</color> to be thrown like
 ModUi/&AllowDruidToWearMetalArmor=Allow <color=#D89555>Druid</color> to wear metal armor
 ModUi/&AllowDungeonsMaxLevel20=Allow dungeons with max level 20
 ModUi/&AllowFlightSuspend=Allow temporarily suspending flight from items and spells <i><color=#F0DAA0>[does not affect wildshape or flying races]</color></i>
+ModUi/&FlightSuspendWingedBoots=<i>+ Use Winged Boots official rules <color=#F0DAA0>[remaining duration not counted when flight suspended]</color></i>
 ModUi/&AllowGadgetsAndPropsToBePlacedAnywhere=Enable <color=#1E81B0>CTRL</color> click to bypass any check when placing gadgets or props
 ModUi/&AllowHasteCasting=Allow casting spells with extra action from being Hasted <color=#F0DAA0>(you are still limited to 1 main action spell per round)</color>
 ModUi/&AllowHornsOnAllRaces=Allow horns on all races <i><color=#F0DAA0>[results might look terrible depending on race, head and horn]</color></i>


### PR DESCRIPTION
The official rules for Winged Boots do not count duration while landed, only when flying. This PR adds a sub-option in Interface for temporarily suspending flight to fix this. Winged Boots remaining duration is resumed when flying again.

![UTduRTc](https://github.com/SolastaMods/SolastaUnfinishedBusiness/assets/3580755/77f09aeb-32c9-48a7-9d50-bd12eb3f3207)

The official rules also allow recharge of the boots every 12 hours, but it is moot in Solasta since players usually go from long rest to long rest, this has not been implemented since not relevant. 