### PR TITLE
Update PrayerOfHealing.json

### DIFF
--- a/Diagnostics/OfficialBlueprints/SpellDefinition/PrayerOfHealing.json
+++ b/Diagnostics/OfficialBlueprints/SpellDefinition/PrayerOfHealing.json
@@ -94,7 +94,7 @@
         "healingForm": {
           "$type": "HealingForm, Assembly-CSharp",
           "healingComputation": "Dice",
-          "diceNumber": 2,
+          "diceNumber": 4,
           "dieType": "D8",
           "bonusHealing": 0,
           "variablePool": false,
@@ -111,7 +111,7 @@
       "incrementMultiplier": 1,
       "additionalTargetsPerIncrement": 0,
       "additionalSubtargetsPerIncrement": 0,
-      "additionalDicePerIncrement": 1,
+      "additionalDicePerIncrement": 2,
       "additionalSpellLevelPerIncrement": 0,
       "additionalSummonsPerIncrement": 0,
       "additionalHPPerIncrement": 0,


### PR DESCRIPTION
Healing has been buffed in one D&D.
I think the buffed content doesn't seem to fit Solastar, so I think it needs to be buffed in a different way. The short rest effect is not suitable even in the Solasta environment, where short rest can be used at any time. So it seems right to increase the healing amount.