### PR TITLE
Update MassHealingWord.json

### DIFF
--- a/Diagnostics/OfficialBlueprints/SpellDefinition/MassHealingWord.json
+++ b/Diagnostics/OfficialBlueprints/SpellDefinition/MassHealingWord.json
@@ -94,7 +94,7 @@
         "healingForm": {
           "$type": "HealingForm, Assembly-CSharp",
           "healingComputation": "Dice",
-          "diceNumber": 1,
+          "diceNumber": 3,
           "dieType": "D4",
           "bonusHealing": 0,
           "variablePool": false,
@@ -111,7 +111,7 @@
       "incrementMultiplier": 1,
       "additionalTargetsPerIncrement": 0,
       "additionalSubtargetsPerIncrement": 0,
-      "additionalDicePerIncrement": 1,
+      "additionalDicePerIncrement": 2,
       "additionalSpellLevelPerIncrement": 0,
       "additionalSummonsPerIncrement": 0,
       "additionalHPPerIncrement": 0,


### PR DESCRIPTION
Healing has been buffed in one D&D.
However, considering that it is a level 3 spell, oneD&D's buff has little effect, so it feels like a little more buffing is needed. So wouldn't it be correct to increase the recovery dice by 1 and increase the upcasting effect dice by 1? Considering that the dice itself is a small spell, I think a healing amount of about 1/4 of the fireball value is correct.