### PR TITLE
Update MassCureWounds.json

### DIFF
--- a/Diagnostics/OfficialBlueprints/SpellDefinition/MassCureWounds.json
+++ b/Diagnostics/OfficialBlueprints/SpellDefinition/MassCureWounds.json
@@ -91,7 +91,7 @@
         "healingForm": {
           "$type": "HealingForm, Assembly-CSharp",
           "healingComputation": "Dice",
-          "diceNumber": 3,
+          "diceNumber": 5,
           "dieType": "D8",
           "bonusHealing": 0,
           "variablePool": false,
@@ -108,7 +108,7 @@
       "incrementMultiplier": 1,
       "additionalTargetsPerIncrement": 0,
       "additionalSubtargetsPerIncrement": 0,
-      "additionalDicePerIncrement": 1,
+      "additionalDicePerIncrement": 2,
       "additionalSpellLevelPerIncrement": 0,
       "additionalSummonsPerIncrement": 0,
       "additionalHPPerIncrement": 0,


### PR DESCRIPTION
Healing has been buffed in one D&D.
The buffed content increases the recovery dice from 3 to 5 And my idea is to increase the upcast dice from 1 to 2. Just as the 1st level spell CureWounds had its upcast dice increased from 1 to 2 in One D&D, I think it makes sense that this spell's upcast dice would also be increased from 1 to 2.