### PR TITLE
Update Regenerate.json

### DIFF
--- a/Diagnostics/OfficialBlueprints/SpellDefinition/Regenerate.json
+++ b/Diagnostics/OfficialBlueprints/SpellDefinition/Regenerate.json
@@ -20,7 +20,7 @@
     "hitAffinitiesByTargetTag": [],
     "targetType": "Individuals",
     "itemSelectionType": "Equiped",
-    "targetParameter": 1,
+    "targetParameter": 3,
     "targetParameter2": 2,
     "emissiveBorder": "None",
     "emissiveParameter": 1,
@@ -91,9 +91,9 @@
         "healingForm": {
           "$type": "HealingForm, Assembly-CSharp",
           "healingComputation": "Dice",
-          "diceNumber": 4,
+          "diceNumber": 5,
           "dieType": "D8",
-          "bonusHealing": 15,
+          "bonusHealing": 30,
           "variablePool": false,
           "healingCap": "MaximumHitPoints"
         },


### PR DESCRIPTION
This order was a mistake by the Solastar production team.  It is a magic that restores amputated body parts.
However, since there is no effect of amputated body parts in Solasta, this spell has become a spell with a lower healing amount than the previous level magic, Recovery. This is clearly a mistake on the part of the Solastar production team.
So I think a buff is needed.