### PR TITLE
ONE D&D Heal buff [CureWounds]

### DIFF
--- a/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
@@ -99,6 +99,7 @@ internal static class SrdAndHouseRulesContext
         SwitchSchoolRestrictionsFromSpellBlade();
         SwitchUniversalSylvanArmorAndLightbringer();
         SwitchUseHeightOneCylinderEffect();
+        SwitchCureWoundsDice();
     }
 
     private static void LoadSenseNormalVisionRangeMultiplier()
@@ -498,6 +499,13 @@ internal static class SrdAndHouseRulesContext
             restrictedActions.RemoveAll(id => id == Id.CastMain);
         }
     }
+
+    internal static void SwitchCureWoundsDice()
+    {
+        CureWounds.effectDescription.effectForms.healingForm.diceNumber = Main.Settings.CureWoundsDice ? 2 : 1;
+        CureWounds.effectDescription.effectAdvancement.additionalDicePerIncrement = Main.Settings.CureWoundsDice ? 2 : 1;
+    }
+
 
     internal static void SwitchAddBleedingToLesserRestoration()
     {


### PR DESCRIPTION
Healing has been buffed in one D&D.
The buffed content increases the recovery dice from 1 to 2, and the dice when upcasting also increases from 1 to 2.
The content of ONE D&D has been implemented as is.
But this is my first time working on it. Is it right to work like this?