### PR TITLE
HealSpell buff

### DIFF
--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -270,6 +270,7 @@ public class Settings : UnityModManager.ModSettings
     public bool UseHeightOneCylinderEffect { get; set; }
     public bool FixEldritchBlastRange { get; set; }
     public bool FixRingOfRegenerationHealRate { get; set; }
+    public bool HealSpellDice { get; set; }
 
     // House
     public bool AllowAnyClassToUseArcaneShieldstaff { get; set; }


### PR DESCRIPTION
Healing spells have been strengthened to match ONE D&D.
CureWounds buffed content increases the recovery dice from 1 to 2, and the dice when upcasting also increases from 1 to 2.
HealingWord buffed content increases the recovery dice from 1 to 2, and the dice when upcasting also increases from 1 to 2.
PrayerOfHealing buffed content increases the recovery dice from 2 to 3, and the dice when upcasting also increases from 1 to 2.
MassHealingWord buffed content increases the recovery dice from 1 to 3, and the dice when upcasting also increases from 1 to 2.
MassCureWounds buffed content increases the recovery dice from 3 to 5, and the dice when upcasting also increases from 1 to 2.