### PR TITLE
queue attack created through attack after magic effect to fix #4679

### DIFF
--- a/SolastaUnfinishedBusiness/Patches/CharacterActionMagicEffectPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/CharacterActionMagicEffectPatcher.cs
@@ -539,7 +539,7 @@ public static class CharacterActionMagicEffectPatcher
                     else
                     {
                         ServiceRepository.GetService<IGameLocationActionService>()?
-                            .ExecuteAction(actionParam, null, false);
+                            .ExecuteAction(actionParam, null, true);
                     }
                 }
             }


### PR DESCRIPTION
without queueing, current action (casting in this case) is interrupted without calling upkeep method that spends action