### PR TITLE
Update SrdAndHouseRulesContext.cs

### DIFF
--- a/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
@@ -365,6 +365,8 @@ internal static class SrdAndHouseRulesContext
     internal static void SwitchOneDndHealingSpellsBuf()
     {
         var dice = Main.Settings.EnableOneDndHealingSpellsBuf ? 2 : 1;
+        var dice2 = Main.Settings.EnableOneDndHealingSpellsBuf ? 5 : 3;
+        var dice3 = Main.Settings.EnableOneDndHealingSpellsBuf ? 3 : 1;
 
         // Cure Wounds, Healing Word got buf on base damage and add dice
         CureWounds.effectDescription.EffectForms[0].healingForm.diceNumber = dice;
@@ -373,8 +375,8 @@ internal static class SrdAndHouseRulesContext
         HealingWord.effectDescription.effectAdvancement.additionalDicePerIncrement = dice;
 
         // Mass Cure Wounds and Mass Healing Word only got buf on base damage
-        MassCureWounds.effectDescription.EffectForms[0].healingForm.diceNumber = dice;
-        MassHealingWord.effectDescription.EffectForms[0].healingForm.diceNumber = dice;
+        MassCureWounds.effectDescription.EffectForms[0].healingForm.diceNumber = dice2;
+        MassHealingWord.effectDescription.EffectForms[0].healingForm.diceNumber = dice3;
     }
 
     internal static void SwitchFilterOnHideousLaughter()


### PR DESCRIPTION
Mass Cure Wounds and Mass Healing Word Fixed incorrect healing values ​​for ONE D&D.
Mass Cure Wounds
5e) 3D8 -> ONED&D) 5D8 but mod) 2D8
Mass Healing Word
5e) 1D4 -> ONED&D) 3D4 but mod) 2D4