### PR TITLE
Fix Psi Warrior's Force of Will to actually use INT

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Do you have a mod you want to see included here? We are happy to take new contri
 # How to compile
 
 0. Install all required development pre-requisites:
-    - [Visual Studio 2022 Community Edition](https://visualstudio.microsoft.com/downloads/)
+    - [Visual Studio 2022 Community Edition 17.8+](https://visualstudio.microsoft.com/downloads/)
     - [.NET x64 6.00.300 SDK](https://dotnet.microsoft.com/download/visual-studio-sdks)
 1. Download and install [Unity Mod Manager (UMM)](https://www.nexusmods.com/site/mods/21)
 2. Execute UMM, Select Solasta, and Install
@@ -53,10 +53,10 @@ NOTE Unity Mod Manager and this mod template make use of [Harmony](https://go.mi
 2. Download and install [7zip](https://www.7-zip.org/a/7z1900-x64.exe)
 3. Download [Unity Editor 2019.4.37](https://download.unity3d.com/download_unity/019e31cfdb15/Windows64EditorInstaller/UnitySetup64-2019.4.37f1.exe)
 4. Open Downloads folder
-	* Right-click UnitySetup64-2019.4.32f1.exe, 7Zip -> Extract Here
+	* Right-click UnitySetup64-2019.4.37f1.exe, 7Zip -> Extract Here
 	* Navigate to Editor\Data\PlaybackEngines\windowsstandalonesupport\Variations\win64_development_mono
 		* Copy *UnityPlayer.dll* and *WinPixEventRuntime.dll* to clipboard
 	* Navigate to the Solasta game folder
 		* Rename *UnityPlayer.dll* to *UnityPlayer.dll.original*
 		* Paste *UnityPlayer.dll* and *WinPixEventRuntime.dll* from clipboard
-5. You can now attach the Unity Debugger from Visual Studio 2019, Debug -> Attach Unity Debug
+5. You can now attach the Unity Debugger from Visual Studio 2022, Debug -> Attach Unity Debug

--- a/SolastaUnfinishedBusiness/Api/Helpers/EffectHelpers.cs
+++ b/SolastaUnfinishedBusiness/Api/Helpers/EffectHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Mono.CSharp;
 using SolastaUnfinishedBusiness.Api.GameExtensions;
 
 namespace SolastaUnfinishedBusiness.Api.Helpers;
@@ -115,9 +116,9 @@ internal static class EffectHelpers
 
     /// <summary>
     /// Utility to replace a saving throw score with a different one.
-    /// If useNewBonuses = false, then only the ability modifier will be replaced.
-    /// If useNewBonuses = true, then the replacement will include all bonuses of the replacement (e.g. proficiency).
-    /// For example, if useNewBonuses = true, and you are replacing a WIS save with INT and you are proficient in INT, you will roll as though it were an INT save.
+    /// If includeProficiency = false, then only the ability modifier will be replaced.
+    /// If includeProficiency = true, then the replacement will include all bonuses of the replacement (e.g. proficiency).
+    /// For example, if includeProficiency = true, and you are replacing a WIS save with INT and you are proficient in INT, you will roll as though it were an INT save.
     /// 
     /// Note that this functions differently from Vanilla.
     /// Vanilla Solasta has the Mana Painter Sorcerer, and its Mana Absorption feature will override the source saving throw be Charisma entirely, if the Charisma mod is higher.
@@ -125,13 +126,13 @@ internal static class EffectHelpers
     ///    1) you get the Charisma proficiency bonus included for being a sorcerer, and
     ///    2) you benefit from features that give you bonuses to Charisma (e.g. Gnome advantage for INT/WIS/CHA)
     /// </summary>
-    internal static bool ReplaceSavingThrowSourceIfHigher(RulesetCharacter defender, string replacementAbilityScoreName, bool useNewBonuses, ref string abilityScoreName, ref int saveBonus, List<RuleDefinitions.TrendInfo> savingThrowModifierTrends)
+    internal static bool ReplaceSavingThrowSourceIfHigher(RulesetCharacter defender, string originalAbilityScore, string replacementAbilityScoreName, bool includeProficiency, ref int saveBonus, List<RuleDefinitions.TrendInfo> savingThrowModifierTrends)
     {
-        if (useNewBonuses)
+        if (includeProficiency)
         {
             List<RuleDefinitions.TrendInfo> oldTrends = new List<RuleDefinitions.TrendInfo>();
             List<RuleDefinitions.TrendInfo> newTrends = new List<RuleDefinitions.TrendInfo>();
-            int origMod = defender.ComputeBaseSavingThrowBonus(abilityScoreName, oldTrends);
+            int origMod = defender.ComputeBaseSavingThrowBonus(originalAbilityScore, oldTrends);
             int replacementMod = defender.ComputeBaseSavingThrowBonus(replacementAbilityScoreName, newTrends); // Expected to return proficiency bonuses included.
             if (replacementMod < origMod)
             {
@@ -158,36 +159,29 @@ internal static class EffectHelpers
 
             // Don't directly set the save bonus, since we don't know what else could be accumulated in there. Use the delta instead.
             saveBonus += replacementMod - origMod;
-            abilityScoreName = replacementAbilityScoreName;
             return true;
         }
         else
         {
-            int origMod = AttributeDefinitions.ComputeAbilityScoreModifier(defender.TryGetAttributeValue(abilityScoreName));
             int replacementMod = AttributeDefinitions.ComputeAbilityScoreModifier(defender.TryGetAttributeValue(replacementAbilityScoreName));
-            if (replacementMod < origMod)
-            {
-                return false;
-            }
 
-            // Search for the original ability and replace it.
+            // Search for the current ability score and replace it.
             for (int i = 0; i < savingThrowModifierTrends.Count; ++i)
             {
                 RuleDefinitions.TrendInfo info = savingThrowModifierTrends[i];
 
-                if (info.sourceType == RuleDefinitions.FeatureSourceType.AbilityScore && info.sourceName == abilityScoreName)
+                if (info.sourceType == RuleDefinitions.FeatureSourceType.AbilityScore && replacementMod > info.value)
                 {
+                    // Don't directly set the saveBonus since it might contain proficiencies. Use the delta instead.
                     saveBonus += replacementMod - info.value;
-                    abilityScoreName = replacementAbilityScoreName;
 
-                    info.value = replacementMod;
-                    info.sourceName = replacementAbilityScoreName;
+                    // Need new assignment because TrendInfo is struct type
+                    savingThrowModifierTrends[i] = new RuleDefinitions.TrendInfo(replacementMod, RuleDefinitions.FeatureSourceType.AbilityScore, replacementAbilityScoreName, null);
 
                     return true; // Assumes only one ability score source
                 }
             }
 
-            // Unexpected for the ability score to not be in the trends.
             return false;
         }
     }

--- a/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
@@ -937,12 +937,8 @@ public sealed class MartialForceKnight : AbstractSubclass
 
             if (abilityScoreName == AttributeDefinitions.Wisdom)
             {
-                var wisdom = defender.TryGetAttributeValue(AttributeDefinitions.Wisdom);
-
-                if (intelligence > wisdom)
+                if (EffectHelpers.ReplaceSavingThrowSourceIfHigher(defender, AttributeDefinitions.Intelligence, true, ref abilityScoreName, ref saveBonus, modifierTrends))
                 {
-                    abilityScoreName = AttributeDefinitions.Intelligence;
-
                     defender.LogCharacterUsedFeature(featureForceOfWill);
                 }
             }
@@ -950,13 +946,9 @@ public sealed class MartialForceKnight : AbstractSubclass
             // ReSharper disable once InvertIf
             if (abilityScoreName == AttributeDefinitions.Charisma)
             {
-                var charisma = defender.TryGetAttributeValue(AttributeDefinitions.Charisma);
-
                 // ReSharper disable once InvertIf
-                if (intelligence > charisma)
+                if (EffectHelpers.ReplaceSavingThrowSourceIfHigher(defender, AttributeDefinitions.Intelligence, true, ref abilityScoreName, ref saveBonus, modifierTrends))
                 {
-                    abilityScoreName = AttributeDefinitions.Intelligence;
-
                     defender.LogCharacterUsedFeature(featureForceOfWill);
                 }
             }

--- a/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
@@ -933,12 +933,11 @@ public sealed class MartialForceKnight : AbstractSubclass
             int outcomeDelta,
             List<EffectForm> effectForms)
         {
-            var intelligence = defender.TryGetAttributeValue(AttributeDefinitions.Intelligence);
-
             if (abilityScoreName == AttributeDefinitions.Wisdom)
             {
-                if (EffectHelpers.ReplaceSavingThrowSourceIfHigher(defender, AttributeDefinitions.Intelligence, true, ref abilityScoreName, ref saveBonus, modifierTrends))
+                if (EffectHelpers.ReplaceSavingThrowSourceIfHigher(defender, abilityScoreName, AttributeDefinitions.Intelligence, true, ref saveBonus, modifierTrends))
                 {
+                    abilityScoreName = AttributeDefinitions.Intelligence;
                     defender.LogCharacterUsedFeature(featureForceOfWill);
                 }
             }
@@ -947,8 +946,9 @@ public sealed class MartialForceKnight : AbstractSubclass
             if (abilityScoreName == AttributeDefinitions.Charisma)
             {
                 // ReSharper disable once InvertIf
-                if (EffectHelpers.ReplaceSavingThrowSourceIfHigher(defender, AttributeDefinitions.Intelligence, true, ref abilityScoreName, ref saveBonus, modifierTrends))
+                if (EffectHelpers.ReplaceSavingThrowSourceIfHigher(defender, abilityScoreName, AttributeDefinitions.Intelligence, true, ref saveBonus, modifierTrends))
                 {
+                    abilityScoreName = AttributeDefinitions.Intelligence;
                     defender.LogCharacterUsedFeature(featureForceOfWill);
                 }
             }


### PR DESCRIPTION
> Psi Warrior
>
> * Force of Will
>
> Your psionic energy grants you extraordinary resilience. At the start of each of your turns, you gain temporary hit points equal to your Intelligence modifier (minimum of 1) if you have at least 1 hit point. In addition, **you can use your Intelligence modifier instead of your Wisdom and Charisma modifier for saving throws if it's higher.**

Currently, when Force of Will is triggered, all that happens is that the displayed saving throw is shown as INT, but it didn't actually use the INT mod. This change fixes that.

![image](https://github.com/SolastaMods/SolastaUnfinishedBusiness/assets/8569010/01557551-e249-47fa-a9c9-62d26e244880)

However, several caveats:

(1) This change considers your saving throw proficiency when doing the replacement. It compares INT [+Prof] against the original WIS [+Prof] or CHA [+Prof], rather than just INT vs WIS/CHA. I like this more because if you get proficiency through sub-classing or feats, you will gain benefit or not lose out just because the base INT vs WIS works differently.

If we'd prefer just INT vs WIS, I have a code path in there to do just that. (Set `useNewBonuses = false`)

(2) The base game Mana Painter Sorcerer has Mana Absorption, which has similar wording:

> Your Charisma modifier is used (if higher) instead of other ability modifiers on your saving throws against spells and other magic effects.

This vanilla feature works by replacing the saving throw entirely to be Charisma if the CHA mod is greater than the original saving throw's ability mod. (This is done through an `ISavingThrowAffinityProvider` in `RulesetImplementationManager.TryRollSavingThrow`).This has interesting consequences, such as the fact that you get CHA proficiency added (to all saving throws basically), you don't benefit from cover against spells that were originally DEX saves, and that bonuses to CHA saves (like gnome adv on INT/WIS/CHA) apply for things like fireball.

This change does not do that. Rather, the save just swaps the ability scores, but is mostly still treated as a saving throw of the original type.

(3) Despite point 2, the saving throw type still does get changed to INT after Force of Will is applied, so any mod power that uses `OnSavingThrowInitiated` will race against it. This is currently not an issue because no Unfinished Business feat applies a bonus to INT/WIS/CHA through that handler. However, if this code will be reused for Barbarian Path of Savagery, then the race needs to be addressed for the Shield Master feat.

>Path of the Savagery
>
> * Furious Defense
>
> Starting at 6th level, while you are raging, **whenever you roll a Dexterity saving throw, you can use your Strength saving throw instead**. You gain +2 AC while you are raging and dual-wielding two melee weapons.