### PR TITLE
Tweak Reverse Gravity to not grant flying to creatures.

### DIFF
--- a/SolastaUnfinishedBusiness/Spells/SpellBuildersLevel07.cs
+++ b/SolastaUnfinishedBusiness/Spells/SpellBuildersLevel07.cs
@@ -53,7 +53,7 @@ internal static partial class SpellBuilders
                                     .SetOrUpdateGuiPresentation(Category.Condition)
                                     .SetConditionType(ConditionType.Neutral)
                                     .SetParentCondition(ConditionDefinitions.ConditionFlying)
-                                    .SetFeatures(FeatureDefinitionMoveModes.MoveModeFly2)
+                                    .SetFeatures()
                                     .AddToDB(),
                                 ConditionForm.ConditionOperation.Add)
                             .HasSavingThrow(EffectSavingThrowType.Negates)


### PR DESCRIPTION
This spell should not grant flying ability according to [Reverse Gravity](https://www.dndbeyond.com/spells/2233-reverse-gravity?msockid=242cc9d5fa03644c3642daabfbd165cc), otherwise it's useless as a 7th level CC spell.