### PR TITLE
Inventory sorting rework

### DIFF
--- a/SolastaUnfinishedBusiness/Models/InventoryManagementContext.cs
+++ b/SolastaUnfinishedBusiness/Models/InventoryManagementContext.cs
@@ -228,21 +228,20 @@ internal static class InventoryManagementContext
 
     private static int ItemSort(RulesetInventorySlot slotA, RulesetInventorySlot slotB)
     {
-        var result = BySortGroup.Inverted ? -1 : 1;
         var itemA = slotA.EquipedItem;
         var itemB = slotB.EquipedItem;
 
         if (itemA == null)
         {
-            return itemB == null ? 0 : result;
+            return itemB == null ? 0 : 1;
         }
 
         if (itemB == null)
         {
-            return -result;
+            return -1;
         }
 
-        result *= SortGuiDropdown.value switch
+        var result = SortGuiDropdown.value switch
         {
             1 => SortByName(itemA, itemB),
             2 => SortByCategory(itemA, itemB),

--- a/SolastaUnfinishedBusiness/Models/InventoryManagementContext.cs
+++ b/SolastaUnfinishedBusiness/Models/InventoryManagementContext.cs
@@ -38,6 +38,9 @@ internal static class InventoryManagementContext
 
     private static Toggle UnidentifiedToggle { get; set; }
     private static GameObject UnidentifiedText { get; set; }
+    
+    private static readonly List<RulesetInventorySlot> Filtered = new();
+    private static bool dirty = true;
 
     internal static void Load()
     {
@@ -81,14 +84,12 @@ internal static class InventoryManagementContext
         UnidentifiedToggle.onValueChanged.RemoveAllListeners();
         UnidentifiedText = Object.Instantiate(byTextMesh.gameObject, rightGroup);
 
-        // changes the reorder button label and refactor the listener
+        // repositions the reorder button and refactor the listener
 
         var reorder = rightGroup.transform.Find("ReorderPersonalContainerButton");
         var reorderButton = reorder.GetComponent<Button>();
-        // var reorderTextMesh = reorder.GetComponentInChildren<TextMeshProUGUI>();
 
         reorder.localPosition = new Vector3(-10f, 358f, 0f);
-        // reorderTextMesh.text = "Reset";
         reorderButton.onClick.RemoveAllListeners();
         reorderButton.onClick.AddListener(delegate
         {
@@ -343,12 +344,13 @@ internal static class InventoryManagementContext
         return tagsMap.Keys.ToArray().Contains(TaggedGuiDropdown.options[taggedIndex].text);
     }
 
+    //`container` parameter is required for the transpile patch
     public static List<RulesetInventorySlot> GetFilteredSlots(RulesetContainer container, ContainerPanel panel)
     {
         return GetFilteredAndSorted(panel);
     }
 
-    public static void BindInventory(ContainerPanel panel, GuiCharacter character)
+    public static void BindInventory(ContainerPanel panel)
     {
         if (!panel.TryGetComponent<InventoryContainerPanelMarker>(out _))
         {
@@ -388,10 +390,6 @@ internal static class InventoryManagementContext
         dirty = true;
         Filtered.Clear();
     }
-
-    private static readonly List<RulesetInventorySlot> Filtered = new();
-    private static bool dirty = true;
-
 
     private static List<RulesetInventorySlot> GetFilteredAndSorted(ContainerPanel panel)
     {

--- a/SolastaUnfinishedBusiness/Models/InventoryManagementContext.cs
+++ b/SolastaUnfinishedBusiness/Models/InventoryManagementContext.cs
@@ -13,7 +13,8 @@ namespace SolastaUnfinishedBusiness.Models;
 
 internal static class InventoryManagementContext
 {
-    public static bool Enabled => Main.Settings.EnableInventoryFilteringAndSorting && !Global.IsMultiplayer;
+    public static bool Enabled => Main.Settings.EnableInventoryFilteringAndSorting
+                                  && (!Global.IsMultiplayer || Main.Settings.AllowSortingInMultiplayer);
 
     private static readonly List<string> SortCategories =
     [

--- a/SolastaUnfinishedBusiness/Patches/CharacterInspectionScreenPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/CharacterInspectionScreenPatcher.cs
@@ -66,12 +66,6 @@ public static class CharacterInspectionScreenPatcher
         {
             //PATCH: resets the inspection context for MC heroes
             Global.InspectedHero = null;
-
-            //PATCH: enables Inventory Filtering and Sorting
-            if (Main.Settings.EnableInventoryFilteringAndSorting && !Global.IsMultiplayer)
-            {
-                InventoryManagementContext.ResetControls();
-            }
         }
     }
 

--- a/SolastaUnfinishedBusiness/Patches/ContainerPanelPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/ContainerPanelPatcher.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection.Emit;
+using HarmonyLib;
+using JetBrains.Annotations;
+using SolastaUnfinishedBusiness.Api.Helpers;
+using SolastaUnfinishedBusiness.Models;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+[UsedImplicitly]
+public static class ContainerPanelPatcher
+{
+    private static IEnumerable<CodeInstruction> ReplaceSlotsGetter(IEnumerable<CodeInstruction> instructions,
+        string context)
+    {
+        var oldMethod = typeof(RulesetContainer).GetProperty(nameof(RulesetContainer.InventorySlots))!.GetGetMethod();
+        var newMethod =
+            typeof(InventoryManagementContext).GetMethod(nameof(InventoryManagementContext.GetFilteredSlots));
+
+        return instructions.ReplaceCalls(oldMethod,  context,
+            new CodeInstruction(OpCodes.Ldarg_0),
+            new CodeInstruction(OpCodes.Call, newMethod));
+    }
+
+    //PATCH: Enable Inventory Filtering and Sorting
+    [HarmonyPatch(typeof(ContainerPanel), nameof(ContainerPanel.RefreshVisibleSlots))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class RefreshVisibleSlots_Patch
+    {
+        [UsedImplicitly]
+        internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            return ReplaceSlotsGetter(instructions, "ContainerPanel.RefreshVisibleSlots");
+        }
+    }
+
+    //PATCH: Enable Inventory Filtering and Sorting
+    [HarmonyPatch(typeof(ContainerPanel), nameof(ContainerPanel.ComputeTableHeight))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class ComputeTableHeight_Patch
+    {
+        [UsedImplicitly]
+        internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            return ReplaceSlotsGetter(instructions, "ContainerPanel.ComputeTableHeight");
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Patches/InventoryPanelPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/InventoryPanelPatcher.cs
@@ -16,13 +16,13 @@ public static class InventoryPanelPatcher
     public static class OnBeginShow_Patch
     {
         [UsedImplicitly]
-        public static void Postfix()
+        public static void Prefix(InventoryPanel __instance)
         {
             InventoryManagementContext.RefreshControlsVisibility();
 
-            if (Main.Settings.EnableInventoryFilteringAndSorting && !Global.IsMultiplayer)
+            if (InventoryManagementContext.Enabled && __instance.MainContainerPanel)
             {
-                InventoryManagementContext.SelectionChanged();
+                InventoryManagementContext.Refresh(__instance.MainContainerPanel);
             }
         }
     }
@@ -34,13 +34,12 @@ public static class InventoryPanelPatcher
     public static class Bind_Patch
     {
         [UsedImplicitly]
-        public static void Postfix(InventoryPanel __instance)
+        public static void Prefix(InventoryPanel __instance,  GuiCharacter guiCharacter)
         {
             // NOTE: don't use MainContainerPanel?. which bypasses Unity object lifetime check
-            if (Main.Settings.EnableInventoryFilteringAndSorting && !Global.IsMultiplayer &&
-                __instance.MainContainerPanel)
+            if (InventoryManagementContext.Enabled && __instance.MainContainerPanel)
             {
-                InventoryManagementContext.SortAndFilter(__instance.MainContainerPanel.Container);
+                InventoryManagementContext.BindInventory(__instance.MainContainerPanel, guiCharacter);
             }
         }
     }
@@ -56,8 +55,7 @@ public static class InventoryPanelPatcher
         {
             if (__instance.MainContainerPanel)
             {
-                // NOTE: don't use MainContainerPanel?. which bypasses Unity object lifetime check
-                InventoryManagementContext.Flush(__instance.MainContainerPanel.Container);
+                InventoryManagementContext.UnbindInventory(__instance.MainContainerPanel);
             }
         }
     }

--- a/SolastaUnfinishedBusiness/Patches/InventoryPanelPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/InventoryPanelPatcher.cs
@@ -34,12 +34,12 @@ public static class InventoryPanelPatcher
     public static class Bind_Patch
     {
         [UsedImplicitly]
-        public static void Prefix(InventoryPanel __instance,  GuiCharacter guiCharacter)
+        public static void Prefix(InventoryPanel __instance)
         {
             // NOTE: don't use MainContainerPanel?. which bypasses Unity object lifetime check
             if (InventoryManagementContext.Enabled && __instance.MainContainerPanel)
             {
-                InventoryManagementContext.BindInventory(__instance.MainContainerPanel, guiCharacter);
+                InventoryManagementContext.BindInventory(__instance.MainContainerPanel);
             }
         }
     }

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -459,6 +459,7 @@ public class Settings : UnityModManager.ModSettings
     public bool AddCustomIconsToOfficialItems { get; set; }
     public bool DisableAutoEquip { get; set; }
     public bool EnableInventoryFilteringAndSorting { get; set; }
+    public bool AllowSortingInMultiplayer { get; set; }
     public bool EnableInventoryTaintNonProficientItemsRed { get; set; }
     public bool EnableInventoryTintKnownRecipesRed { get; set; }
     public bool EnableInvisibleCrownOfTheMagister { get; set; }

--- a/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
@@ -333,6 +333,7 @@ UI/&InventoryFilterCategory=Category
 UI/&InventoryFilterCost=Cost
 UI/&InventoryFilterCostPerWeight=Cost per Weight
 UI/&InventoryFilterName=Name
+UI/&InventoryFilterNone=No Sorting
 UI/&InventoryFilterUnidentifiedMagical=Unidentified Magical
 UI/&InventoryFilterWeight=Weight
 UI/&RecipeFilterAll=All


### PR DESCRIPTION
Made inventory sorting and filtering be UI-only, instead of old implementation that removed and reordered actual items in inventory. This implementation _should_ work in MP - but I have not tested it. By default it is still disabled for MP, but I've added hidden setting to make it work in MP if someone brave wants to test it.