### PR TITLE
some fixes

### DIFF
--- a/SolastaUnfinishedBusiness/Models/SaveByLocationContext.cs
+++ b/SolastaUnfinishedBusiness/Models/SaveByLocationContext.cs
@@ -133,7 +133,7 @@ internal static class SaveByLocationContext
                     (
                         d,
                         Directory.EnumerateFiles(d, "*.sav").Max(f => (DateTime?)File.GetLastWriteTimeUtc(f)),
-                        LocationType.UserLocation
+                        LocationType.CustomCampaign
                     ))
             .Concat(
                 Directory.EnumerateDirectories(OfficialSaveGameDirectory)
@@ -141,7 +141,7 @@ internal static class SaveByLocationContext
                     (
                         d,
                         Directory.EnumerateFiles(d, "*.sav").Max(f => (DateTime?)File.GetLastWriteTimeUtc(f)),
-                        LocationType.UserLocation
+                        LocationType.StandardCampaign
                     ))
             .Concat(
                 Enumerable.Repeat(
@@ -171,6 +171,7 @@ internal static class SaveByLocationContext
 
         // Find the most recently touched save file and select the correct location/campaign for that save
         var (path, locationType) = GetMostRecent();
+        Main.Log2($"SaveByLocation: most recent: {locationType} at '{path}'");
 
         ServiceRepositoryEx.GetOrCreateService<SelectedCampaignService>()
             .SetCampaignLocation(locationType, Path.GetFileName(path));

--- a/SolastaUnfinishedBusiness/Patches/RulesetImplementationManagerLocationPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetImplementationManagerLocationPatcher.cs
@@ -51,8 +51,10 @@ public static class RulesetImplementationManagerLocationPatcher
             ref string failure)
         {
             //PATCH: support for custom metamagic
-            var validator = metamagicOption.GetFirstSubFeatureOfType<ValidateMetamagicApplication>();
-            validator?.Invoke(caster, rulesetEffectSpell, metamagicOption, ref __result, ref failure);
+            foreach (var validator in metamagicOption.GetAllSubFeaturesOfType<ValidateMetamagicApplication>())
+            {
+                validator.Invoke(caster, rulesetEffectSpell, metamagicOption, ref __result, ref failure);
+            }
         }
     }
 

--- a/SolastaUnfinishedBusiness/Subclasses/CollegeOfAudacity.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/CollegeOfAudacity.cs
@@ -188,6 +188,7 @@ public sealed class CollegeOfAudacity : AbstractSubclass
             .RequiresAuthorization()
             .SetActionId(ExtraActionId.AudaciousWhirlToggle)
             .OverrideClassName("Toggle")
+            .SetActivatedPower(powerAudaciousWhirl, false)
             .AddToDB();
 
         var featureSetAudaciousWhirl = FeatureDefinitionFeatureSetBuilder

--- a/SolastaUnfinishedBusiness/Subclasses/DomainTempest.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/DomainTempest.cs
@@ -500,10 +500,12 @@ public sealed class DomainTempest : AbstractSubclass
         private static void MaybeAddPushForm(
             // ReSharper disable once SuggestBaseTypeForParameter
             GameLocationCharacter attacker,
-            RulesetCharacter rulesetDefender,
+            [CanBeNull] RulesetCharacter rulesetDefender,
             // ReSharper disable once SuggestBaseTypeForParameter
             List<EffectForm> actualEffectForms)
         {
+            if (rulesetDefender == null) { return; }
+
             if (attacker.IsMyTurn() &&
                 actualEffectForms
                     .Any(x =>

--- a/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
@@ -54,6 +54,7 @@ public sealed class MartialForceKnight : AbstractSubclass
             .SetActionId(ExtraActionId.ForcePoweredStrikeToggle)
             .OverrideClassName("Toggle")
             .AddCustomSubFeatures(new ActionItemDiceBoxForcePoweredStrike())
+            .SetActivatedPower(PowerPsionicInitiate, false)
             .AddToDB();
 
         var additionalDamageForcePoweredStrike = FeatureDefinitionAdditionalDamageBuilder

--- a/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
@@ -745,10 +745,6 @@ public sealed class MartialForceKnight : AbstractSubclass
 
             var armorClass = defender.RulesetCharacter.TryGetAttributeValue(AttributeDefinitions.ArmorClass);
             var attackRoll = action.AttackRoll;
-
-            //auto hit - skip
-            if (attackMode?.AutomaticHit == true && attackRoll == DiceMaxValue[(int)DieType.D20]) { yield break; }
-
             var totalAttack =
                 attackRoll +
                 (attackMode?.ToHitBonus ?? rulesetEffect?.MagicAttackBonus ?? 0) +

--- a/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/MartialForceKnight.cs
@@ -744,6 +744,10 @@ public sealed class MartialForceKnight : AbstractSubclass
 
             var armorClass = defender.RulesetCharacter.TryGetAttributeValue(AttributeDefinitions.ArmorClass);
             var attackRoll = action.AttackRoll;
+
+            //auto hit - skip
+            if (attackMode?.AutomaticHit == true && attackRoll == DiceMaxValue[(int)DieType.D20]) { yield break; }
+
             var totalAttack =
                 attackRoll +
                 (attackMode?.ToHitBonus ?? rulesetEffect?.MagicAttackBonus ?? 0) +


### PR DESCRIPTION
- fixed crash if Tempest Strike eligible AoE spell/power hits object
- fixed twinned spell offered for blade cantrips (again)
- ~do not offer Kinetic Barrier reaction if attacker rolled natural 20 or has AutoHit flag in attack mode~ reverted
- fixed Force Powered Strike and Audacious Whirl missing their toggle actions
- fix save by location/campaign setting using a wrong location type for custom or default campaigns