### PR TITLE
Fix crash from party creatures being dead, dying or unconscious

### DIFF
--- a/SolastaUnfinishedBusiness/Patches/ActiveCharacterPanelPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/ActiveCharacterPanelPatcher.cs
@@ -21,13 +21,20 @@ public static class ActiveCharacterPanelPatcher
     public static class Refresh_Patch
     {
         [UsedImplicitly]
-        public static void Postfix(ActiveCharacterPanel __instance)
+        public static bool Prefix(ActiveCharacterPanel __instance)
         {
             //prevent null check issues
             if (__instance.GuiCharacter?.RulesetCharacter is not { IsDeadOrDyingOrUnconscious: false })
             {
-                return;
+                return false;
             }
+
+            return true;
+        }
+
+        [UsedImplicitly]
+        public static void Postfix(ActiveCharacterPanel __instance)
+        {
 
             //PATCH: support for custom point pools and concentration powers on portrait
             IconsOnPortrait.CharacterPanelRefresh(__instance);


### PR DESCRIPTION
Moved the null check from the Postfix to a Prefix, where it skips the Refresh() method if the creature IsDeadOrDyingOrUnconscious.

[Video of successful interaction.](https://i.imgur.com/ZFI7zi4.mp4)



Related to this bug mentioned in the Discord channel: https://discord.com/channels/583281506739290125/774339139444670494/1288406189411012608
