### PR TITLE
Grapple and cheese grater fixes

### DIFF
--- a/SolastaUnfinishedBusiness/Models/GrappleContext.cs
+++ b/SolastaUnfinishedBusiness/Models/GrappleContext.cs
@@ -544,8 +544,10 @@ internal static class GrappleContext
             if (canTeleport)
             {
                 target.StartTeleportTo(targetDestinationPosition, mover.Orientation, false);
+                target.Pushed = true;
                 target.FinishMoveTo(targetDestinationPosition, mover.Orientation);
                 target.StopMoving(mover.Orientation);
+                target.Pushed = false;
 
                 var isLastStep = GetDistanceFromCharacter(mover, mover.DestinationPosition) <= 1;
 

--- a/SolastaUnfinishedBusiness/Models/GrappleContext.cs
+++ b/SolastaUnfinishedBusiness/Models/GrappleContext.cs
@@ -97,6 +97,11 @@ internal static class GrappleContext
             .SetBrain(battlePackage, true)
             .SetFeatures(
                 ActionAffinityGrappled,
+                //prevent grappled target from falling while grappled
+                FeatureDefinitionMoveModeBuilder.Create($"{ConditionGrappleTargetName}Flying")
+                    .SetGuiPresentation(Category.Feature)
+                    .SetMode(MoveMode.Fly, 0)
+                    .AddToDB(),
                 ActionAffinityConditionRestrained,
                 MovementAffinityConditionRestrained)
             .AddCustomSubFeatures(new OnConditionAddedOrRemovedConditionGrappleTarget())

--- a/SolastaUnfinishedBusiness/Patches/GameLocationPositioningManagerPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/GameLocationPositioningManagerPatcher.cs
@@ -30,5 +30,19 @@ public static class GameLocationPositioningManagerPatcher
             return instructions.ReplaceCalls(logErrorMethod, "GameLocationPositioningManager.CharacterMoved",
                 new CodeInstruction(OpCodes.Pop));
         }
+
+        [UsedImplicitly]
+        public static bool Prefix(GameLocationCharacter character,
+            int3 oldPosition,
+            int3 newPosition,
+            RulesetActor.SizeParameters oldSize,
+            RulesetActor.SizeParameters newSize)
+        {
+            //PATCH: process location change only if position or size has changed
+            //FIX: fixes Spike Growth and similar spells triggering twice on last tile of movement
+            return oldPosition != newPosition
+                   || oldSize.minExtent != newSize.minExtent
+                   || oldSize.maxExtent != newSize.maxExtent;
+        }
     }
 }

--- a/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Others-en.txt
@@ -92,6 +92,7 @@ Feature/&AttributeModifierDazzledTitle=Dazzled
 Feature/&AttributeModifierMonkAbundantKiDescription=Add half your proficiency bonus (rounded down) to your Ki Points pool.
 Feature/&AttributeModifierMonkAbundantKiTitle=Abundant Ki
 Feature/&CollegeHopeWanderingHealerSpellsDescription={0}\n\n
+Feature/&ConditionGrappleTargetFlyingDescription=Follows grappler
 Feature/&EnhancedIndomitableResistanceDescription=If you fail a saving throw, you can reroll it with a bonus equal to your Fighter level. If you do so, you must use the new roll, and you can't use this feature again until you finish a long rest.
 Feature/&ExpandedSpellsDescription={0}\n\n
 Feature/&ExpandedSpellsTitle=Expanded Spells


### PR DESCRIPTION
- fixed Spike Growth and similar effects applying twice on entering last tile of movement
- fixed movement by grappling not triggering damage from Spike Growth and similar effects (fixes #4972)
- fixed being unable to lift grappled target off the ground if grappler is flying 