### PR TITLE
OneDnd make healing potions a bonus action

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
+++ b/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
@@ -141,6 +141,13 @@ internal static class CraftingAndItems
             SrdAndHouseRulesContext.SwitchRingOfRegenerationHealRate();
         }
 
+        toggle = Main.Settings.OneDndHealingPotionBonusAction;
+        if (UI.Toggle(Gui.Localize("ModUi/&OneDndHealingPotionBonusAction"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.OneDndHealingPotionBonusAction = toggle;
+            SrdAndHouseRulesContext.SwitchOneDndHealingPotionBonusAction();
+        }
+
         UI.Label();
 
         toggle = Main.Settings.AddCustomIconsToOfficialItems;

--- a/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
+++ b/SolastaUnfinishedBusiness/Models/SrdAndHouseRulesContext.cs
@@ -15,6 +15,7 @@ using static SolastaUnfinishedBusiness.Api.DatabaseHelper.ConditionDefinitions;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.SpellDefinitions;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.MonsterDefinitions;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.FeatureDefinitionConditionAffinitys;
+using static SolastaUnfinishedBusiness.Api.DatabaseHelper.FeatureDefinitionPowers;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.FeatureDefinitionSenses;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.CharacterClassDefinitions;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.ItemDefinitions;
@@ -100,6 +101,7 @@ internal static class SrdAndHouseRulesContext
         SwitchMagicStaffFoci();
         SwitchAllowTargetingSelectionWhenCastingChainLightningSpell();
         SwitchOfficialFoodRationsWeight();
+        SwitchOneDndHealingPotionBonusAction();
         SwitchOneDndHealingSpellsBuf();
         SwitchRecurringEffectOnEntangle();
         SwitchRingOfRegenerationHealRate();
@@ -400,6 +402,34 @@ internal static class SrdAndHouseRulesContext
         foreach (var featureUnlock in Wizard.FeatureUnlocks.Where(featureUnlock => featureUnlock.level == fromLevel))
         {
             featureUnlock.level = toLevel;
+        }
+    }
+
+    internal static void SwitchOneDndHealingPotionBonusAction()
+    {
+        if (Main.Settings.OneDndHealingPotionBonusAction)
+        {
+            PowerFunctionPotionOfHealing.activationTime = ActivationTime.BonusAction;
+            PowerFunctionPotionOfHealingOther.activationTime = ActivationTime.BonusAction;
+            PowerFunctionPotionOfGreaterHealing.activationTime = ActivationTime.BonusAction;
+            PowerFunctionPotionOfGreaterHealingOther.activationTime = ActivationTime.BonusAction;
+            PowerFunctionPotionOfSuperiorHealing.activationTime = ActivationTime.BonusAction;
+            PowerFunctionPotionOfSuperiorHealingOther.activationTime = ActivationTime.BonusAction;
+            PowerFunctionPotionRemedy.activationTime = ActivationTime.BonusAction;
+            PowerFunctionRemedyOther.activationTime = ActivationTime.BonusAction;
+            PowerFunctionAntitoxin.activationTime = ActivationTime.BonusAction;
+        }
+        else
+        {
+            PowerFunctionPotionOfHealing.activationTime = ActivationTime.Action;
+            PowerFunctionPotionOfHealingOther.activationTime = ActivationTime.Action;
+            PowerFunctionPotionOfGreaterHealing.activationTime = ActivationTime.Action;
+            PowerFunctionPotionOfGreaterHealingOther.activationTime = ActivationTime.Action;
+            PowerFunctionPotionOfSuperiorHealing.activationTime = ActivationTime.Action;
+            PowerFunctionPotionOfSuperiorHealingOther.activationTime = ActivationTime.Action;
+            PowerFunctionPotionRemedy.activationTime = ActivationTime.Action;
+            PowerFunctionRemedyOther.activationTime = ActivationTime.Action;
+            PowerFunctionAntitoxin.activationTime = ActivationTime.Action;
         }
     }
 

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -305,6 +305,7 @@ public class Settings : UnityModManager.ModSettings
     public bool EnableInventoryTaintNonProficientItemsRed { get; set; }
     public bool EnableInventoryTintKnownRecipesRed { get; set; }
     public bool SwapCraftedItemAndRecipeIcons { get; set; }
+    public bool OneDndHealingPotionBonusAction { get; set; }
     public int SetBeltOfDwarvenKindBeardChances { get; set; } = 50;
 
     // Crafting

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -226,6 +226,7 @@ ModUi/&OfficialObscurementRulesInvisibleCreaturesCanBeTarget=<i>+ Invisible crea
 ModUi/&OfficialObscurementRulesMagicalDarknessAsProjectileBlocker=<i>+ Change <color=#D89555>magically obscured</color> areas to be projectile blockers <color=#F0DAA0>[any source of the <color=#D89555>Darkness</color> spell effect]</color></i>
 ModUi/&OfficialObscurementRulesTweakMonsters=<i>+ Add <color=#D89555>Darkvision</color>, <color=#D89555>BlindSight</color>, and <color=#D89555>TrueSight</color> to monsters and NPCs whenever appropriate</i>
 ModUi/&OfficialObscurementRulesTweakMonstersHelp=<i><color=#F0DAA0>[settings' collections <b>MonstersThatShouldHaveDarkvision</b>, <b>MonstersThatShouldHaveTrueSight</b>, <b>MonstersThatShouldHaveBlindSight</b>]</color></i>
+ModUi/&OneDndHealingPotionBonusAction=Enable OneDnD <color=#D89555>Healing Potions</color> and <color=#D89555>Antitoxin</color> use Bonus Action
 ModUi/&OnlyShowMostPowerfulUpcastConjuredElementalOrFey=<i>+ Only show the most powerful creatures in the conjuration list</i>
 ModUi/&OutlineGridWidthModifier=<color=white>Multiply the outline grid width by</color> <color=#C04040E0>[%]</color>
 ModUi/&OutlineGridWidthSpeed=<color=white>Multiply the outline grid animation speed by</color> <color=#C04040E0>[%]</color>


### PR DESCRIPTION
Option for new OneDnd rules for healing potions in the 2024 Player's Handbook that make healing potions and antitoxin a bonus action