### PR TITLE
Abjuration school fixes

### DIFF
--- a/SolastaUnfinishedBusiness/Behaviors/ForceUsesAttributeDeserialization.cs
+++ b/SolastaUnfinishedBusiness/Behaviors/ForceUsesAttributeDeserialization.cs
@@ -1,0 +1,27 @@
+﻿using SolastaUnfinishedBusiness.Api.GameExtensions;
+
+namespace SolastaUnfinishedBusiness.Behaviors;
+
+public class ForceUsesAttributeDeserialization
+{
+    private ForceUsesAttributeDeserialization()
+    {
+    }
+
+    public static ForceUsesAttributeDeserialization Mark { get; } = new();
+
+    internal static void Process(RulesetCharacter character, IElementsSerializer serializer)
+    {
+        if (serializer.Mode != Serializer.SerializationMode.Read) { return; }
+
+        var usablePowers = character.usablePowers;
+        for (var index = 0; index < usablePowers.Count; ++index)
+        {
+            var usablePower = usablePowers[index];
+            var powerDefinition = usablePower.PowerDefinition;
+            if (!powerDefinition.HasSubFeatureOfType<ForceUsesAttributeDeserialization>()) { continue; }
+
+            usablePower.UsesAttribute = character.GetAttribute(powerDefinition.UsesAbilityScoreName);
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Patches/RulesetCharacterPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetCharacterPatcher.cs
@@ -500,6 +500,20 @@ public static class RulesetCharacterPatcher
                 .Sum(m => m.PoolChangeAmount(__instance));
         }
     }
+    
+    [HarmonyPatch(typeof(RulesetCharacter), nameof(RulesetCharacter.SerializeElements))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class SerializeElements_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(RulesetCharacter __instance,   IElementsSerializer serializer)
+        {
+            //PATCH: allow marking  some powers to read their uses attribute on load even if uses determination is not AbilityBonusPlusFixed
+            //used for BG3 mode toggle in Abjuration wizard's Arcane Ward
+           ForceUsesAttributeDeserialization.Process(__instance, serializer);
+        }
+    }
 
     //PATCH: correctly syncs powers used during WS back to original hero
     [HarmonyPatch(typeof(RulesetCharacter), nameof(RulesetCharacter.SetupFromSubstituteCharacter))]

--- a/SolastaUnfinishedBusiness/Subclasses/WizardAbjuration.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/WizardAbjuration.cs
@@ -56,6 +56,7 @@ public sealed class WizardAbjuration : AbstractSubclass
             new CustomBehaviorArcaneWard(),
             ModifyPowerVisibility.Hidden,
             HasModifiedUses.Marker,
+            ForceUsesAttributeDeserialization.Mark,
             new ModifyPowerRechargeHandler(LimitArcaneWardRecharge),
             new ModifyPowerPoolAmount
             {

--- a/SolastaUnfinishedBusiness/Subclasses/WizardAbjuration.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/WizardAbjuration.cs
@@ -510,10 +510,15 @@ public sealed class WizardAbjuration : AbstractSubclass
         }
     }
 
-    private sealed class ArcaneWardPortraitPoints() : PowerPortraitPointPool(PowerArcaneWard, Sprites.ArcaneWardPoints)
+    private sealed class ArcaneWardPortraitPoints : PowerPortraitPointPool
     {
         public override string TooltipFormat => IsBg3Mode
             ? $"PortraitPool{PowerArcaneWard.Name}BG3PointsFormat"
             : $"PortraitPool{PowerArcaneWard.Name}PointsFormat";
+
+        public ArcaneWardPortraitPoints() : base(PowerArcaneWard, Sprites.ArcaneWardPoints)
+        {
+            IsActiveHandler = character => IsBg3Mode || character.HasConditionOfType(ArcaneWardConditionName);
+        }
     }
 }


### PR DESCRIPTION
- fixed Arcane Ward displaying on portrait when it is inactive
- fixed Arcane Ward portrait points producing NPE when BG3 mode is turned off after loading a save with BG3 mode turned on