### PR TITLE
Fix crash with Projected Ward on non-characters

### DIFF
--- a/SolastaUnfinishedBusiness/Subclasses/WizardAbjuration.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/WizardAbjuration.cs
@@ -534,7 +534,7 @@ public sealed class WizardAbjuration : AbstractSubclass
             RulesetAttackMode attackMode,
             RulesetEffect rulesetEffect)
         {
-            if (action.AttackRollOutcome == RollOutcome.Failure)
+            if (action.AttackRollOutcome == RollOutcome.Failure || defender.RulesetCharacter == null)
             {
                 yield break;
             }
@@ -551,6 +551,7 @@ public sealed class WizardAbjuration : AbstractSubclass
             SavingThrowData savingThrowData,
             bool hasHitVisual)
         {
+            if(defender.RulesetCharacter == null) { yield break; }
             var effectDescription = savingThrowData.EffectDescription;
             var canForceHalfDamage = attacker != null
                                      && savingThrowData.SourceDefinition is SpellDefinition spell


### PR DESCRIPTION
Found a case where Projected Ward was reacting to non-characters taking damage, and then trying to access properties of its RulesetCharacter, so I added an early break if the defender is not a character in both `TryAlterOutcomeAttack` (not sure if attacks can be made against non-characters, but just in case) and `TryAlterOutcomeSavingThrow`.