### PR TITLE
Enable Wildfire Spirit to act if summoner is incapacitated

### DIFF
--- a/SolastaUnfinishedBusiness/Subclasses/CircleOfTheWildfire.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/CircleOfTheWildfire.cs
@@ -588,8 +588,10 @@ public sealed class CircleOfTheWildfire : AbstractSubclass
                 return true;
             }
 
-            //can act if summoner is KO
-            return summoner.IsUnconscious ||
+            //can act if summoner is Incapacitated
+            return summoner.IsIncapacitated ||
+                   summoner.HasAnyFeature(FeatureDefinitionActionAffinitys.ActionAffinityConditionIncapacitated) ||
+                   summoner.isDeadOrDyingOrUnconscious ||
                    //can act if summoner commanded
                    summoner.HasConditionOfType(ConditionCommandSpirit);
         }


### PR DESCRIPTION
Previously, it only allowed to act if the summoner was unconscious. 5e Official version says it can act if the summoner is Incapacitated, so I check for that too (I'm not sure if there's overlap in Dying->Incapacitated, i.e. if checking for incapacitated already catches dying).

Only checking `RulesetCharacter.IsIncapacitated` wasn't catching all cases (eg. _ConditionCharmedByHypnoticPattern_), so I check to see if the summoner has _ActionAffinityConditionIncapacitated_ as well. The spirit still despawns on the summoner's death, so the check for _IsDeadOrDyingOrUnconscious_ should only matter for the latter two cases.

I have tested it with Hypnotic Pattern and Dying, and it correctly alllows the spirit to take Actions.