### PR TITLE
Fix Beast Barbarian reaction power texts

### DIFF
--- a/SolastaUnfinishedBusiness/Subclasses/PathOfTheBeast.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PathOfTheBeast.cs
@@ -705,7 +705,7 @@ public sealed class PathOfTheBeast : AbstractSubclass
                 usablePower,
                 [defender],
                 attacker,
-                "InfectiousFury",
+                "PowerInfectiousFury",
                 battleManager: battleManager);
         }
     }
@@ -838,7 +838,7 @@ internal class PowerCallTheHuntHandler(FeatureDefinitionPower power) : IActionFi
             usablePower,
             targets,
             character,
-            "CallTheHunt",
+            "PowerCallTheHunt",
             reactionValidated: ReactionValidated);
 
         yield break;


### PR DESCRIPTION
https://cdn.discordapp.com/attachments/774339139444670494/1303680386982744074/image.png?ex=672ca279&is=672b50f9&hm=a9a17cf9b73c17d966f2e09f9833f17e6fde8b223f6e5f69dbf11d6f954ce8e0&

Texts were broken in reactions because they expected the words "UsePower<X>" instead of just "Use<X>". I've simply added the word in.

![Untitled](https://github.com/user-attachments/assets/c35d26d3-6eda-4a3e-91c8-16d100da09a2)
