### PR TITLE
implement 2 options - potions/ scrolls work in ammunition or offhand

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
+++ b/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
@@ -160,6 +160,20 @@ internal static class CraftingAndItems
             Main.Settings.KeepInvisibilityWhenUsingItems = toggle;
         }
 
+        toggle = Main.Settings.EnableVersatileAmmunitionSlots;
+        if (UI.Toggle(Gui.Localize("ModUi/&EnableVersatileAmmunitionSlots"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.EnableVersatileAmmunitionSlots = toggle;
+            ItemCraftingMerchantContext.SwitchVersatileInventorySlots();
+        }
+
+        toggle = Main.Settings.EnableVersatileOffHandSlot;
+        if (UI.Toggle(Gui.Localize("ModUi/&EnableVersatileOffHandSlot"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.EnableVersatileOffHandSlot = toggle;
+            ItemCraftingMerchantContext.SwitchVersatileInventorySlots();
+        }
+
         UI.Label();
 
         toggle = Main.Settings.AddCustomIconsToOfficialItems;

--- a/SolastaUnfinishedBusiness/Models/ItemCraftingMerchantContext.cs
+++ b/SolastaUnfinishedBusiness/Models/ItemCraftingMerchantContext.cs
@@ -282,7 +282,9 @@ internal static class ItemCraftingMerchantContext
     internal static void SwitchVersatileInventorySlots()
     {        
        foreach (var item in DatabaseRepository.GetDatabase<ItemDefinition>()
-            .Where(a => a.UsableDeviceDescription != null && (a.UsableDeviceDescription.UsableDeviceTags.Contains("Potion") ||
+            .Where(a => a.UsableDeviceDescription != null &&
+            a.UsableDeviceDescription.UsableDeviceTags != null &&
+            (a.UsableDeviceDescription.UsableDeviceTags.Contains("Potion") ||
             a.UsableDeviceDescription.UsableDeviceTags.Contains("Scroll"))))
        {
            if (Main.Settings.EnableVersatileAmmunitionSlots && Main.Settings.EnableVersatileOffHandSlot)

--- a/SolastaUnfinishedBusiness/Models/ItemCraftingMerchantContext.cs
+++ b/SolastaUnfinishedBusiness/Models/ItemCraftingMerchantContext.cs
@@ -34,6 +34,7 @@ internal static class ItemCraftingMerchantContext
         SwitchRestockArcaneum();
         SwitchRestockCircleOfDanantar();
         SwitchRestockTowerOfKnowledge();
+        SwitchVersatileInventorySlots();
         LoadDontDisplayHelmets();
     }
 
@@ -275,6 +276,50 @@ internal static class ItemCraftingMerchantContext
         foreach (var stock in Store_Merchant_TowerOfKnowledge_Maddy_Greenisle.StockUnitDescriptions)
         {
             stock.reassortAmount = 1;
+        }
+    }
+
+    internal static void SwitchVersatileInventorySlots()
+    {        
+       foreach (var item in DatabaseRepository.GetDatabase<ItemDefinition>()
+            .Where(a => a.UsableDeviceDescription != null && (a.UsableDeviceDescription.UsableDeviceTags.Contains("Potion") ||
+            a.UsableDeviceDescription.UsableDeviceTags.Contains("Scroll"))))
+       {
+           if (Main.Settings.EnableVersatileAmmunitionSlots && Main.Settings.EnableVersatileOffHandSlot)
+           {
+                item.SlotTypes.SetRange("UtilitySlot",
+                    "ContainerSlot",
+                    "AmmunitionSlot",
+                    "OffHandSlot");
+                item.SlotsWhereActive.SetRange("UtilitySlot",
+                    "AmmunitionSlot",
+                    "OffHandSlot");
+           }
+
+           if (Main.Settings.EnableVersatileAmmunitionSlots && !Main.Settings.EnableVersatileOffHandSlot)
+            {
+                item.SlotTypes.SetRange("UtilitySlot",
+                    "ContainerSlot",
+                    "AmmunitionSlot");
+                item.SlotsWhereActive.SetRange("UtilitySlot",
+                    "AmmunitionSlot");
+            }
+            
+            if (!Main.Settings.EnableVersatileAmmunitionSlots && Main.Settings.EnableVersatileOffHandSlot)
+            {
+                item.SlotTypes.SetRange("UtilitySlot",
+                    "ContainerSlot",
+                    "OffHandSlot");
+                item.SlotsWhereActive.SetRange("UtilitySlot",
+                    "OffHandSlot");
+            }
+
+            if (!Main.Settings.EnableVersatileAmmunitionSlots && !Main.Settings.EnableVersatileOffHandSlot)
+            {
+                item.SlotTypes.SetRange("UtilitySlot",
+                    "ContainerSlot");
+                item.SlotsWhereActive.SetRange("UtilitySlot");
+            }
         }
     }
 

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -229,6 +229,8 @@ public class Settings : UnityModManager.ModSettings
     public bool EnableInventoryFilteringAndSorting { get; set; }
     public bool EnableInventoryTaintNonProficientItemsRed { get; set; }
     public bool EnableInventoryTintKnownRecipesRed { get; set; }
+    public bool EnableVersatileAmmunitionSlots { get; set; }
+    public bool EnableVersatileOffHandSlot {  get; set; }
     public int SetBeltOfDwarvenKindBeardChances { get; set; } = 50;
 
     // Crafting

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -181,6 +181,8 @@ ModUi/&EnableTooltipDistance=Enable showing distance on tooltips when hovering o
 ModUi/&EnableUnarmedMainAttackAction=Enable the <color=#D89555>Unarmed Attack</color> action <i><color=#F0DAA0>[if actor has weapon in main, is a <b>Monk</b> or has <b>handwraps</b> or <b>gauntlet</b> equipped]</color></i>
 ModUi/&EnableUpcastConjureElementalAndFey=Enable upcast of <color=#D89555>Conjure Elemental</color> and <color=#D89555>Conjure Fey</color>
 ModUi/&EnableVariablePlaceholdersOnTexts=Enable variable placeholders on descriptions <i><color=#F0DAA0>[use {VARIABLE_NAME} as placeholder]</color></i>
+ModUi/&EnableVersatileAmmunitionSlots=Allow <color=#D89555>Potions</color> and <color=#D89555>Scrolls</color> to be carried and used in the Ammuntion slots
+ModUi/&EnableVersatileOffHandSlot=Allow <color=#D89555>Potions</color> and <color=#D89555>Scrolls</color> to be carried and used in the Off-hand Weapon slot
 ModUi/&EnableWarlockMagicalCunningAtLevel2=Enable <color=#D89555>Magical Cunning</color> at level 2
 ModUi/&EnableWarlockMagicalCunningAtLevel2AndImprovedEldritchMasterAt20=Enable <color=#D89555>Magical Cunning</color> at level 2 and improve <color=#D89555>Eldritch Master</color> at 20
 ModUi/&EnableWarlockToLearnPatronAtLevel3=Enable <color=#D89555>Patron</color> at level 3 instead of 1


### PR DESCRIPTION
Allows potions or scrolls to be used in off-hand slots, ammunition slots, or both.