### PR TITLE
Change healing spells to Abjuration school

### DIFF
--- a/SolastaUnfinishedBusiness/Models/SpellsContext.cs
+++ b/SolastaUnfinishedBusiness/Models/SpellsContext.cs
@@ -44,6 +44,7 @@ internal static class SpellsContext
     internal static readonly SpellDefinition AirBlast = BuildAirBlast();
     internal static readonly SpellDefinition AshardalonStride = BuildAshardalonStride();
     internal static readonly SpellDefinition AuraOfLife = BuildAuraOfLife();
+    internal static readonly SpellDefinition AuraOfVitality = BuildAuraOfVitality();
     internal static readonly SpellDefinition BanishingSmite = BuildBanishingSmite();
     internal static readonly SpellDefinition BindingIce = BuildBindingIce();
     internal static readonly SpellDefinition BlessingOfRime = BuildBlessingOfRime();
@@ -334,7 +335,7 @@ internal static class SpellsContext
         RegisterSpell(BuildAdderFangs(), 0, SpellListDruid, SpellListRanger, SpellListSorcerer, SpellListWarlock);
         RegisterSpell(AshardalonStride, 0, SpellListRanger, SpellListSorcerer, SpellListWizard,
             spellListInventorClass);
-        RegisterSpell(BuildAuraOfVitality(), 0, SpellListCleric, SpellListPaladin);
+        RegisterSpell(AuraOfVitality, 0, SpellListCleric, SpellListPaladin);
         RegisterSpell(BlindingSmite, 0, SpellListPaladin);
         RegisterSpell(BuildBoomingStep(), 0, SpellListSorcerer, SpellListWarlock, SpellListWizard);
         RegisterSpell(CorruptingBolt, 0, SpellListSorcerer, SpellListWarlock, SpellListWizard);

--- a/SolastaUnfinishedBusiness/Models/Tabletop2024Context.cs
+++ b/SolastaUnfinishedBusiness/Models/Tabletop2024Context.cs
@@ -1044,6 +1044,15 @@ internal static class Tabletop2024Context
         dice = Main.Settings.EnableOneDndHealingSpellsUpgrade ? 5 : 3;
 
         MassCureWounds.EffectDescription.EffectForms[0].healingForm.diceNumber = dice;
+
+        var school = Main.Settings.EnableOneDndHealingSpellsUpgrade ? SchoolAbjuration : SchoolEvocation;
+        SpellsContext.AuraOfVitality.schoolOfMagic = school;
+        CureWounds.schoolOfMagic = school;
+        Heal.schoolOfMagic = school;
+        HealingWord.schoolOfMagic = school;
+        MassCureWounds.schoolOfMagic = school;
+        MassHealingWord.schoolOfMagic = school;
+        PrayerOfHealing.schoolOfMagic = school;
     }
 
     internal static void SwitchOneDndDamagingSpellsUpgrade()


### PR DESCRIPTION
As per 2024 ruleset, each of the following schools moved from Evocation to Abjuration:

Healing Word
Cure Wounds
Prayer of Healing
Aura of Vitality
Mass Healing Word
Mass Cure Wounds
Heal
Mass Heal (this is not implemented in UB as of now).

I've just tagged the school change along into the option to use 2024's improved healing spells.