### PR TITLE
Enable InvocationPactBlade to use CHA for weapon attacks

### DIFF
--- a/SolastaUnfinishedBusiness/Models/Tabletop2024Context.cs
+++ b/SolastaUnfinishedBusiness/Models/Tabletop2024Context.cs
@@ -197,10 +197,12 @@ internal static class Tabletop2024Context
         .SetSpecialInterruptions(ConditionInterruption.SavingThrow)
         .AddToDB();
 
-    private static readonly InvocationDefinition InvocationPactBlade = InvocationDefinitionBuilder
+    internal static readonly InvocationDefinition InvocationPactBlade = InvocationDefinitionBuilder
         .Create("InvocationPactBlade")
         .SetGuiPresentation(FeatureSetPactBlade.GuiPresentation)
         .SetGrantedFeature(FeatureSetPactBlade)
+        .AddCustomSubFeatures(
+            new CanUseAttribute(AttributeDefinitions.Charisma, PatronSoulBlade.CanWeaponBeEmpowered))
         .AddToDB();
 
     private static readonly InvocationDefinition InvocationPactChain = InvocationDefinitionBuilder

--- a/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
@@ -223,7 +223,7 @@ public sealed class PatronSoulBlade : AbstractSubclass
     // ReSharper disable once UnassignedGetOnlyAutoProperty
     internal override DeityDefinition DeityDefinition { get; }
 
-    private static bool CanWeaponBeEmpowered(RulesetAttackMode mode, RulesetItem item, RulesetCharacter character)
+    public static bool CanWeaponBeEmpowered(RulesetAttackMode mode, RulesetItem item, RulesetCharacter character)
     {
         if (character is not RulesetCharacterHero hero)
         {
@@ -237,7 +237,8 @@ public sealed class PatronSoulBlade : AbstractSubclass
         {
             canWeaponBeEmpowered =
                 ValidatorsWeapon.IsTwoHanded(mode) &&
-                hero.ActiveFeatures.Any(p => p.Value.Contains(FeatureDefinitionFeatureSets.FeatureSetPactBlade));
+                (hero.ActiveFeatures.Any(p => p.Value.Contains(FeatureDefinitionFeatureSets.FeatureSetPactBlade)) ||
+                hero.HasActiveInvocation(Tabletop2024Context.InvocationPactBlade));
         }
 
         return canWeaponBeEmpowered;

--- a/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/PatronSoulBlade.cs
@@ -223,7 +223,7 @@ public sealed class PatronSoulBlade : AbstractSubclass
     // ReSharper disable once UnassignedGetOnlyAutoProperty
     internal override DeityDefinition DeityDefinition { get; }
 
-    public static bool CanWeaponBeEmpowered(RulesetAttackMode mode, RulesetItem item, RulesetCharacter character)
+    internal static bool CanWeaponBeEmpowered(RulesetAttackMode mode, RulesetItem item, RulesetCharacter character)
     {
         if (character is not RulesetCharacterHero hero)
         {


### PR DESCRIPTION
and Fix Hexblade to work with InvocationPactBlade for 2H weapons.


2024 Pact of the Blade invocation also allows you to use CHA with the bonded weapon. I've added the same qualifier from Hexblade to the invocation.

I also fixed Hexblade condition only looking for the Pact of the Blade _feature_, which doesn't exist if you enable the 2024 Pact invocations option; it will now also consider the invocation.

![Untitled](https://github.com/user-attachments/assets/ffd8e8b4-9bd5-4f17-b4da-0ec6d110950a)