### PR TITLE
All potions and weapon poisons take a bonus action in 2024 DMG

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
+++ b/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
@@ -147,11 +147,18 @@ internal static class CraftingAndItems
             Main.Settings.IgnoreHandXbowFreeHandRequirements = toggle;
         }
 
-        toggle = Main.Settings.OneDndHealingPotionBonusAction;
-        if (UI.Toggle(Gui.Localize("ModUi/&OneDndHealingPotionBonusAction"), ref toggle, UI.AutoWidth()))
+        toggle = Main.Settings.OneDndAllPotionsBonusAction;
+        if (UI.Toggle(Gui.Localize("ModUi/&OneDndAllPotionsBonusAction"), ref toggle, UI.AutoWidth()))
         {
-            Main.Settings.OneDndHealingPotionBonusAction = toggle;
-            Tabletop2024Context.SwitchOneDndHealingPotionBonusAction();
+            Main.Settings.OneDndAllPotionsBonusAction = toggle;
+            Tabletop2024Context.SwitchOneDndAllPotionsBonusAction();
+        }
+
+        toggle = Main.Settings.OneDndPoisonsBonusAction;
+        if (UI.Toggle(Gui.Localize("ModUi/&OneDndPoisonsBonusAction"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.OneDndPoisonsBonusAction = toggle;
+            Tabletop2024Context.SwitchOneDndPoisonsBonusAction();
         }
 
         toggle = Main.Settings.KeepInvisibilityWhenUsingItems;

--- a/SolastaUnfinishedBusiness/Displays/GeneralDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/GeneralDisplay.cs
@@ -277,11 +277,18 @@ internal static class ToolsDisplay
             Tabletop2024Context.SwitchOneDndSurprisedEnforceDisadvantage();
         }
 
-        toggle = Main.Settings.OneDndHealingPotionBonusAction;
-        if (UI.Toggle(Gui.Localize("ModUi/&OneDndHealingPotionBonusAction"), ref toggle, UI.AutoWidth()))
+        toggle = Main.Settings.OneDndAllPotionsBonusAction;
+        if (UI.Toggle(Gui.Localize("ModUi/&OneDndAllPotionsBonusAction"), ref toggle, UI.AutoWidth()))
         {
-            Main.Settings.OneDndHealingPotionBonusAction = toggle;
-            Tabletop2024Context.SwitchOneDndHealingPotionBonusAction();
+            Main.Settings.OneDndAllPotionsBonusAction = toggle;
+            Tabletop2024Context.SwitchOneDndAllPotionsBonusAction();
+        }
+
+        toggle = Main.Settings.OneDndPoisonsBonusAction;
+        if (UI.Toggle(Gui.Localize("ModUi/&OneDndPoisonsBonusAction"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.OneDndPoisonsBonusAction = toggle;
+            Tabletop2024Context.SwitchOneDndPoisonsBonusAction();
         }
 
         UI.Label();

--- a/SolastaUnfinishedBusiness/Models/Tabletop2024Context.cs
+++ b/SolastaUnfinishedBusiness/Models/Tabletop2024Context.cs
@@ -433,6 +433,7 @@ internal static class Tabletop2024Context
         SwitchOneDndEnableBardWordsOfCreationAtLevel20();
         SwitchOneDnDEnableDruidUseMetalArmor();
         SwitchOneDndAllPotionsBonusAction();
+        SwitchOneDndPoisonsBonusAction();
         SwitchOneDndDamagingSpellsUpgrade();
         SwitchOneDndHealingSpellsUpgrade();
         SwitchOneDndMonkUnarmedDieTypeProgression();

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -228,7 +228,8 @@ public class Settings : UnityModManager.ModSettings
     public bool MakeAllMagicStaveArcaneFoci { get; set; }
     public bool FixRingOfRegenerationHealRate { get; set; }
     public bool IgnoreHandXbowFreeHandRequirements { get; set; }
-    public bool OneDndHealingPotionBonusAction { get; set; }
+    public bool OneDndAllPotionsBonusAction { get; set; }
+    public bool OneDndPoisonsBonusAction { get; set; }
     public bool KeepInvisibilityWhenUsingItems { get; set; }
     public bool AddCustomIconsToOfficialItems { get; set; }
     public bool DisableAutoEquip { get; set; }

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -277,7 +277,8 @@ ModUi/&OfficialObscurementRulesMagicalDarknessAsProjectileBlocker=<i>+ Change <c
 ModUi/&OfficialObscurementRulesTweakMonsters=<i>+ Add <color=#D89555>Darkvision</color>, <color=#D89555>BlindSight</color>, and <color=#D89555>TrueSight</color> to monsters and NPCs whenever appropriate</i>
 ModUi/&OfficialObscurementRulesTweakMonstersHelp=<i><color=#F0DAA0>[settings' collections <b>MonstersThatShouldHaveDarkvision</b>, <b>MonstersThatShouldHaveTrueSight</b>, <b>MonstersThatShouldHaveBlindSight</b>]</color></i>
 ModUi/&OneDnd=<color=#F0DAA0>Tabletop <i>[5e 2024]</i>:</color>
-ModUi/&OneDndHealingPotionBonusAction=Enable bonus action on <color=#D89555>Healing Potions</color> and <color=#D89555>Antitoxin</color> usages
+ModUi/&OneDndAllPotionsBonusAction=Enable drinking <color=#D89555>Potions</color> as a bonus action
+ModUi/&OneDndPoisonsBonusAction=Enable applying <color=#D89555>Poisons</color> to weapons as a bonus action
 ModUi/&OnlyShowMostPowerfulUpcastConjuredElementalOrFey=<i>+ Only show the most powerful creatures in the conjuration list</i>
 ModUi/&OutlineGridWidthModifier=<color=white>Multiply the outline grid width by</color> <color=#C04040E0>[%]</color>
 ModUi/&OutlineGridWidthSpeed=<color=white>Multiply the outline grid animation speed by</color> <color=#C04040E0>[%]</color>


### PR DESCRIPTION
Verified that in the 2024 DMG drinking all potions is a bonus action (not just healing), also applying poison to a weapon is a bonus action. Separate options for each are now provided. 