### PR TITLE
Fix Corrupting Bolt doubling Save effect dmg and ending on missed atks

### DIFF
--- a/SolastaUnfinishedBusiness/Spells/SpellBuildersLevel03.cs
+++ b/SolastaUnfinishedBusiness/Spells/SpellBuildersLevel03.cs
@@ -323,15 +323,7 @@ internal static partial class SpellBuilders
             .Create(ConditionEyebiteSickened, $"Condition{Name}")
             .SetGuiPresentation(Category.Condition, ConditionDoomLaughter)
             .SetConditionType(ConditionType.Detrimental)
-            .SetFeatures(
-                DatabaseRepository.GetDatabase<DamageDefinition>()
-                    .Select(damageDefinition =>
-                        FeatureDefinitionDamageAffinityBuilder
-                            .Create($"DamageAffinity{Name}{damageDefinition.Name}")
-                            .SetGuiPresentationNoContent(true)
-                            .SetDamageAffinityType(DamageAffinityType.Vulnerability)
-                            .SetDamageType(damageDefinition.Name)
-                            .AddToDB()))
+            .SetFeatures() // remove eyebite features
             .AddCustomSubFeatures(new CustomBehaviorCorruptingBolt())
             .AddToDB();
 
@@ -369,9 +361,47 @@ internal static partial class SpellBuilders
         return spell;
     }
 
-    private sealed class CustomBehaviorCorruptingBolt : IPhysicalAttackFinishedOnMe, IMagicEffectFinishedOnMe
+    private sealed class CustomBehaviorCorruptingBolt :
+        ITryAlterOutcomeAttack,
+        IPhysicalAttackFinishedOnMe,
+        IMagicEffectFinishedOnMe
     {
-        private const string ConditionCorruptingBoltName = "ConditionCorruptingBolt";
+        private const string Name = "CorruptingBolt";
+        private const string ConditionCorruptingBoltName = $"Condition{Name}";
+
+        private static FeatureDefinitionDamageAffinity[] VulnerabilityFeatures =
+            DatabaseRepository.GetDatabase<DamageDefinition>()
+                    .Select(damageDefinition =>
+                        FeatureDefinitionDamageAffinityBuilder
+                            .Create($"DamageAffinity{Name}{damageDefinition.Name}")
+                            .SetGuiPresentationNoContent(true)
+                            .SetDamageAffinityType(DamageAffinityType.Vulnerability)
+                            .SetDamageType(damageDefinition.Name)
+                            .AddToDB()
+                    ).ToArray();
+
+        public int HandlerPriority => 10;
+
+        public IEnumerator OnTryAlterOutcomeAttack(
+            GameLocationBattleManager instance,
+            CharacterAction action,
+            GameLocationCharacter attacker,
+            GameLocationCharacter defender,
+            GameLocationCharacter helper,
+            ActionModifier actionModifier,
+            RulesetAttackMode attackMode,
+            RulesetEffect rulesetEffect)
+        {
+            var rulesetDefender = defender.RulesetCharacter;
+
+            if ((attackMode is not null || rulesetEffect.EffectDescription.NeedsToRollDie()) &&
+                rulesetDefender.TryGetConditionOfCategoryAndType(
+                    AttributeDefinitions.TagEffect, ConditionCorruptingBoltName, out var activeCondition))
+            {
+                activeCondition.ConditionDefinition.features.SetRange(VulnerabilityFeatures);
+            }
+            yield break;
+        }
 
         public IEnumerator OnMagicEffectFinishedOnMe(
             CharacterAction action,
@@ -380,22 +410,26 @@ internal static partial class SpellBuilders
             List<GameLocationCharacter> targets)
         {
             var rulesetEffect = action.ActionParams.RulesetEffect;
-
-            if (rulesetEffect.EffectDescription.RangeType is not (RangeType.MeleeHit or RangeType.RangeHit))
-            {
-                yield break;
-            }
-
             var rulesetAttacker = action.ActingCharacter.RulesetCharacter;
             var rulesetDefender = defender.RulesetCharacter;
 
-            if (rulesetDefender.TryGetConditionOfCategoryAndType(
-                    AttributeDefinitions.TagEffect, ConditionCorruptingBoltName, out var activeCondition) &&
-                !rulesetAttacker.SpellsCastByMe.Any(x => x.TrackedConditionGuids.Contains(activeCondition.Guid)))
+            if (rulesetEffect.EffectDescription.NeedsToRollDie() &&
+                rulesetDefender.TryGetConditionOfCategoryAndType(
+                    AttributeDefinitions.TagEffect, ConditionCorruptingBoltName, out var activeCondition))
             {
-                rulesetDefender.RemoveAllConditionsOfCategoryAndType(
-                    AttributeDefinitions.TagEffect, ConditionCorruptingBoltName);
+                if (action.AttackRollOutcome is (RollOutcome.Success or RollOutcome.CriticalSuccess) &&
+                    !rulesetAttacker.SpellsCastByMe.Any(x => x.TrackedConditionGuids.Contains(activeCondition.Guid)))
+                {
+                    rulesetDefender.RemoveAllConditionsOfCategoryAndType(
+                        AttributeDefinitions.TagEffect, ConditionCorruptingBoltName);
+                }
+                else
+                {
+                    activeCondition.ConditionDefinition.features.Clear();
+                }
             }
+
+            yield break;
         }
 
         public IEnumerator OnPhysicalAttackFinishedOnMe(
@@ -409,8 +443,19 @@ internal static partial class SpellBuilders
         {
             var rulesetDefender = defender.RulesetCharacter;
 
-            rulesetDefender.RemoveAllConditionsOfCategoryAndType(
-                AttributeDefinitions.TagEffect, ConditionCorruptingBoltName);
+            if (rulesetDefender.TryGetConditionOfCategoryAndType(
+                    AttributeDefinitions.TagEffect, ConditionCorruptingBoltName, out var activeCondition))
+            {
+                if (action.AttackRollOutcome is (RollOutcome.Success or RollOutcome.CriticalSuccess))
+                {
+                    rulesetDefender.RemoveAllConditionsOfCategoryAndType(
+                        AttributeDefinitions.TagEffect, ConditionCorruptingBoltName);
+                }
+                else
+                {
+                    activeCondition.ConditionDefinition.features.Clear();
+                }
+            }
 
             yield break;
         }


### PR DESCRIPTION
Fix SolastaMods/SolastaUnfinishedBusiness#5161

God, that took me way longer than it should have. I forgot `ITryAlterOutcomeAttack` existed at first, so there was another, worse approach before this one causing a bunch of edge cases. This approach is better, but probably could be cleaner as I'm not super familiar with properties of attacks.

Correct me if I'm wrong, but `attackMode is not null` covers the case for weapon attacks, and  `rulesetEffect.effectDescription.NeedsToRollDie()` covers the case for attack spells (whereas rulesetEffect.EffectDescription is null on weapon attacks?).

I tested this with:
- weapon attack on miss (condition not removed)
- weapon attack on hit (damage doubled and condition removed)
- Save spell (not doubled, condition not removed)
- Attack spell on miss (condition not removed)
- Attack spell on hit (damage doubled and condition removed)
- Attack spell on miss, but Powerful Cantrip (damage not doubled, condition not removed)