### PR TITLE
Add setting to allow flight on ally movement features

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/CampaignsDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/CampaignsDisplay.cs
@@ -320,6 +320,12 @@ internal static class CampaignsDisplay
                 Main.Settings.NeverMoveCameraOnEnemyTurn = toggle;
             }
 
+            toggle = Main.Settings.EnableForceAllyMovementAllowsFlight;
+            if (UI.Toggle(Gui.Localize("ModUi/&EnableAllyMovementAllowsFlight"), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.EnableForceAllyMovementAllowsFlight = toggle;
+            }
+
             UI.Label();
         }
 

--- a/SolastaUnfinishedBusiness/Models/Tabletop2024Context.cs
+++ b/SolastaUnfinishedBusiness/Models/Tabletop2024Context.cs
@@ -17,6 +17,7 @@ using static SolastaUnfinishedBusiness.Api.DatabaseHelper.FeatureDefinitionFeatu
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.FeatureDefinitionFightingStyleChoices;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper.FeatureDefinitionMovementAffinitys;
 using static SolastaUnfinishedBusiness.Api.DatabaseHelper;
+using SolastaUnfinishedBusiness.Api.ModKit.Utility;
 
 namespace SolastaUnfinishedBusiness.Models;
 
@@ -523,14 +524,16 @@ internal static partial class Tabletop2024Context
             var halfMaxTacticalMoves = (actingCharacter.MaxTacticalMoves + 1) / 2; // half-rounded up
             var boxInt = new BoxInt(actingCharacter.LocationPosition, int3.zero, int3.zero);
 
-            boxInt.Inflate(halfMaxTacticalMoves, 0, halfMaxTacticalMoves);
+            if (Main.Settings.EnableForceAllyMovementAllowsFlight) { boxInt.Inflate(halfMaxTacticalMoves); }
+            else { boxInt.Inflate(halfMaxTacticalMoves, 0, halfMaxTacticalMoves); }
 
             foreach (var position in boxInt.EnumerateAllPositionsWithin())
             {
-                if (!positioningService.CanPlaceCharacter(
+                if ((double)int3.Distance(cursorLocationSelectPosition.centerPosition, position) > (double)halfMaxTacticalMoves || 
+                    !positioningService.CanPlaceCharacter(
                         actingCharacter, position, CellHelpers.PlacementMode.Station) ||
                     !positioningService.CanCharacterStayAtPosition_Floor(
-                        actingCharacter, position, onlyCheckCellsWithRealGround: true))
+                        actingCharacter, position, onlyCheckCellsWithRealGround: Main.Settings.EnableForceAllyMovementAllowsFlight))
                 {
                     continue;
                 }

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -186,6 +186,7 @@ public class Settings : UnityModManager.ModSettings
     public bool DontFollowCharacterInBattle { get; set; }
     public bool EnableElevationCameraToStayAtPosition { get; set; }
     public bool NeverMoveCameraOnEnemyTurn { get; set; }
+    public bool EnableForceAllyMovementAllowsFlight { get; set; }
     public bool EnableCancelEditOnRightMouseClick { get; set; }
     public int DontFollowMargin { get; set; } = 5;
     public int GridSelectedColor { get; set; } = 1;

--- a/SolastaUnfinishedBusiness/Subclasses/MartialWarlord.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/MartialWarlord.cs
@@ -452,15 +452,15 @@ public sealed class MartialWarlord : AbstractSubclass
             var halfMaxTacticalMoves = (targetCharacter.MaxTacticalMoves + 1) / 2; // half-rounded up
             var boxInt = new BoxInt(targetCharacter.LocationPosition, int3.zero, int3.zero);
 
-            boxInt.Inflate(halfMaxTacticalMoves, 0, halfMaxTacticalMoves);
+            if (Main.Settings.EnableForceAllyMovementAllowsFlight) { boxInt.Inflate(halfMaxTacticalMoves); }
+            else { boxInt.Inflate(halfMaxTacticalMoves, 0, halfMaxTacticalMoves); }
 
             foreach (var position in boxInt.EnumerateAllPositionsWithin())
             {
-                if (!visibilityService.MyIsCellPerceivedByCharacter(position, actingCharacter) ||
-                    !positioningService.CanPlaceCharacter(
-                        actingCharacter, position, CellHelpers.PlacementMode.Station) ||
+                if (!positioningService.CanPlaceCharacter(
+                        targetCharacter, position, CellHelpers.PlacementMode.Station) ||
                     !positioningService.CanCharacterStayAtPosition_Floor(
-                        actingCharacter, position, onlyCheckCellsWithRealGround: true))
+                        targetCharacter, position, onlyCheckCellsWithRealGround: cursorLocationSelectPosition.isTeleportingSpell))
                 {
                     continue;
                 }

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -21,6 +21,7 @@ ModUi/&AllowDisplayingNonSuggestedSpells=Allow mod non suggested spells on each 
 ModUi/&AllowDisplayingOfficialSpells=Allow game official spells on each list
 ModUi/&AllowDungeonsMaxLevel20=Allow dungeons with max level 20
 ModUi/&AllowFlightSuspend=Allow temporarily suspending flight from items and spells <i><color=#F0DAA0>[does not affect Wild Shape or flying races]</color></i>
+ModUi/&EnableAllyMovementAllowsFlight=Allow features that move self or allies to include mid-air positions if that creature is flying (eg. <color=#D89555>Maneuvering Strike</color>, <color=#D89555>Instinctive Pounce</color>)
 ModUi/&AllowGadgetsAndPropsToBePlacedAnywhere=Enable <color=#1E81B0>CTRL</color> click to bypass any check when placing gadgets or props
 ModUi/&AllowHasteCasting=Allow casting spells with extra action from being Hasted <i><color=#F0DAA0>[you are still limited to 1 main action spell per round]</color></i>
 ModUi/&AllowHornsOnAllRaces=Allow horns on all races <i><color=#F0DAA0>[results might look terrible depending on race, head and horn]</color></i>


### PR DESCRIPTION
Fix SolastaMods/SolastaUnfinishedBusiness#5162

Add a setting under Gameplay->Campaigns->Combat to allow features that let other allies move, use those allies' flight.

Covers the following features:
- Warlord's _Strategic Reposition_
- Battle Master's _Maneuvering Strike_
- 2024 Fighter's _Tactical Shift_
- 2024 Barbarian's _Instinctive Pounce_

![Disabled](https://github.com/user-attachments/assets/60f61052-8112-44ea-99eb-0daf9c2b7cbb)
![Enabled](https://github.com/user-attachments/assets/4489ee8c-e3f5-4dfd-9d6f-e130c38125c7)
