### PR TITLE
Fix druid wildshape duration

### DIFF
--- a/SolastaUnfinishedBusiness/Patches/RuleDefinitionsPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RuleDefinitionsPatcher.cs
@@ -54,7 +54,7 @@ public static class RuleDefinitionsPatcher
     public static class IsPositionImmuneToSpell_Patch
     {
         [UsedImplicitly]
-        public static void Postfix(out bool __result, int spellLevel, int totalSpellLevel)
+        public static void Postfix(out bool __result, int spellLevel, ref int totalSpellLevel)
         {
             __result = totalSpellLevel != 0 && spellLevel <= totalSpellLevel;
         }


### PR DESCRIPTION
- replace classLevel calculations for HalfClassLevelHours durations in RulesetEfefctPower's constructor - native one assumes power comes from class that already has subclass picked, so it breaks if such power is granted on a class before subclass pick (e.g. Druid with Circle selection moved to level 3)
- fixed broken patch for `RuleDefinitions.IsPositionImmuneToSpell` - `totalSpellLevel` parameter is marked as `out` in base method, needs to have `ref` or `out` in the patch