### PR TITLE
Fix 8be71f2 when Cleric learns subclass at Lv3 enableld

### DIFF
--- a/SolastaUnfinishedBusiness/Patches/CharacterBuildingManagerPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/CharacterBuildingManagerPatcher.cs
@@ -573,7 +573,8 @@ public static class CharacterBuildingManagerPatcher
         public static bool Prefix([NotNull] RulesetCharacterHero hero)
         {
             //PATCH: avoid Domain Nature to break level up with the cantrip pool it gets
-            ResetCantripsPool(hero, $"{AttributeDefinitions.TagSubclass}Cleric1DomainNatureDomainNature");
+            ResetCantripsPool(hero, $"{AttributeDefinitions.TagSubclass}Cleric"
+                + (Main.Settings.EnableClericToLearnDomainAtLevel3 ? 3 : 1) +"DomainNatureDomainNature");
 
             //PATCH: un-captures the desired subclass
             LevelUpHelper.SetSelectedSubclass(hero, null);


### PR DESCRIPTION
Fix crash that would occur when on the Subclass Selection screen, clicking Nature Domain, then another Domain, then Nature Domain again.

Same issue as https://github.com/SolastaMods/SolastaUnfinishedBusiness/commit/8be71f29021f46e928eb0def68138a6b97ba18e8 but for when the 2024 setting to enable Cleric subclass choice at Lv.3 is enabled.