### PR TITLE
Way Of Shadow: exclude caster from darkness effects

### DIFF
--- a/SolastaUnfinishedBusiness/Subclasses/WayOfTheShadow.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/WayOfTheShadow.cs
@@ -86,6 +86,7 @@ public sealed class WayOfShadow : AbstractSubclass
                 EffectDescriptionBuilder
                     .Create(Darkness)
                     .SetTargetingData(Side.All, RangeType.Distance, 12, TargetType.Sphere, 3)
+                    .ExcludeCaster()
                     .SetEffectForms()
                     .Build())
             .AddCustomSubFeatures(new PowerOrSpellFinishedByMeDarkness(SpellDarkness))


### PR DESCRIPTION
Unfortunately, I have no Windows PC (everything I own runs linux), so as far as I know I can't compile this and test it. Based on nothing more than gut instinct, I tried to track down how to exclude the Way of Shadow monk from being blinded by their own darkness. I have only the faintest glimmer of hope that it will work.

---

Following the 2024 Warrior of Shadow (which seems to be what the current Way of Shadow subclass is built around), the monk should be able to see through their own Darkness ability.

> You can see within the spell’s area when you cast it with this feature.

This adds '.ExcludeCaster()' to the Way of Shadow's Darkness ability, to match the 2024 rules.