### PR TITLE
Add SuperiorDarkvision to list of senses ignored by Umbral Sight feature

### DIFF
--- a/SolastaUnfinishedBusiness/Subclasses/RangerGloomStalker.cs
+++ b/SolastaUnfinishedBusiness/Subclasses/RangerGloomStalker.cs
@@ -289,7 +289,7 @@ public sealed class RangerGloomStalker : AbstractSubclass
             return Main.Settings.AllowAlliesToPerceiveRangerGloomStalkerInNaturalDarkness &&
                    attacker.Side == defender.Side
                 ? []
-                : [SenseMode.Type.Darkvision];
+                : [SenseMode.Type.Darkvision, SenseMode.Type.SuperiorDarkvision];
         }
     }
 


### PR DESCRIPTION
Ranger Gloomstalker with Umbral Sight feature was not seeing the benefit against certain enemies. Discord users correctly identified that it wasn't accounting for "Superior Darkvision", ignoring only regular Darkvision.

Add Superior Darkvision to the list of ignored senses.